### PR TITLE
write with pep8 standards "imports"

### DIFF
--- a/files/Persepolis Download Manager
+++ b/files/Persepolis Download Manager
@@ -16,7 +16,11 @@
 
 from newopen import Open
 import osCommands
-import os , sys , time , ast , argparse
+import os
+import sys
+import time
+import ast
+import argparse
 import struct
 import json
 import platform


### PR DESCRIPTION
اینم از سر بیکاری بود
ولی بهتره کل پروژه رو با استاندارد PEP8 ببرید جلو تا یه پروژه استاندارد باشه و اگه کسی خواست سورس رو بخونه راحت تر باشه