### PR TITLE
Launch aria2 with --rpc-allow-origin-all

### DIFF
--- a/persepolis/scripts/download.py
+++ b/persepolis/scripts/download.py
@@ -67,14 +67,14 @@ def startAria():
     if os_type == 'Linux' or os_type == 'FreeBSD' or os_type == 'OpenBSD':
         os.system("aria2c --version 1> /dev/null")
         os.system("aria2c --no-conf  --enable-rpc --rpc-listen-port '" +
-                  str(port) + "' --rpc-max-request-size=2M --rpc-listen-all --quiet=true &")
+                  str(port) + "' --rpc-max-request-size=2M --rpc-listen-all --rpc-allow-origin-all --quiet=true &")
     elif os_type == 'Darwin':
         cwd = sys.argv[0]
         cwd = os.path.dirname(cwd)
         aria2d = cwd + "/aria2c"
         os.system("'" + aria2d + "' --version 1> /dev/null")
         os.system("'" + aria2d + "' --no-conf  --enable-rpc --rpc-listen-port '" +
-                  str(port) + "' --rpc-max-request-size=2M --rpc-listen-all --quiet=true &")
+                  str(port) + "' --rpc-max-request-size=2M --rpc-listen-all --rpc-allow-origin-all --quiet=true &")
 
     elif os_type == 'Windows':
         NO_WINDOW = 0x08000000
@@ -84,7 +84,7 @@ def startAria():
 
         # aria2 command in windows
         subprocess.Popen([aria2d, '--no-conf', '--enable-rpc', '--rpc-listen-port=' + str(port),
-                          '--rpc-max-request-size=2M', '--rpc-listen-all', '--quiet=true'], shell=False, creationflags=NO_WINDOW)
+                          '--rpc-max-request-size=2M', '--rpc-listen-all', '--rpc-allow-origin-all', '--quiet=true'], shell=False, creationflags=NO_WINDOW)
 
     time.sleep(2)
     answer = aria2Version()


### PR DESCRIPTION
Currently the bundled aria2 executable is launched without rpc-allow-origin-all, which would allow browser plugins exporting links to aria2, or anything talking to aria2 via RPC to work, thus eliminating the need of having 2 functionally identical process / file taking up resources (though minimum) on the machine.

I added the argument, though it's not tested (too lazy to make it on my download machine), it should work.