### PR TITLE
fixed path errors in executing commands

### DIFF
--- a/persepolis/scripts/browser_integration.py
+++ b/persepolis/scripts/browser_integration.py
@@ -174,7 +174,7 @@ def browserIntegration(browser):
     f.close()
 
     if os_type != 'Windows':
-        os.system('chmod +x "' + str(native_message_file) + '"')
+        os.system('chmod +x \"' + str(native_message_file) + '\"')
 
     else:
         import winreg
@@ -240,7 +240,7 @@ def browserIntegration(browser):
         f.close()
 
         # make persepolis_run_shell executable
-        os.system('chmod +x ' + exec_path)
 
 
  
+        os.system('chmod +x \"' + exec_path + '\"')


### PR DESCRIPTION
add " (double quotes) to system.execs in browser integration file (paths with spaces within wasn't executing properly)