### PR TITLE
Use shutil.move instead of copy to reduce IO

### DIFF
--- a/persepolis/scripts/download.py
+++ b/persepolis/scripts/download.py
@@ -532,8 +532,7 @@ def downloadCompleteAction(parent, path, download_path, file_name, file_size):
         if free_space >= file_size:
             # move the file to the download folder
             try:
-                shutil.copy(str(path) ,str(file_path) )
-                os.remove(path)
+                shutil.move(str(path) ,str(file_path) )
 
             except:
                 logger.sendToLog('Persepolis can not move file', "ERROR")


### PR DESCRIPTION
shutil.move is basically shutil.copy2(src, dst) and then os.remove(src), but "if the destination is on the current filesystem, then os.rename() is used". This would reduce the overhead of copying and removing the source file.
Documentation link: https://docs.python.org/2/library/shutil.html