### PR TITLE
Use shutil.move instead of copy to reduce IO

### DIFF
--- a/persepolis/scripts/download.py
+++ b/persepolis/scripts/download.py
@@ -532,8 +532,8 @@ def downloadCompleteAction(parent, path, download_path, file_name, file_size):
         if free_space >= file_size:
             # move the file to the download folder
             try:
-                shutil.copy(str(path) ,str(file_path) )
-                os.remove(path)
+                # use shutil.copy instead of the default copy2
+                shutil.move(str(path) ,str(file_path) , shutil.copy)
 
             except:
                 logger.sendToLog('Persepolis can not move file', "ERROR")
@@ -550,8 +550,7 @@ def downloadCompleteAction(parent, path, download_path, file_name, file_size):
     else:
         # move the file to the download folder
         try:
-            shutil.copy(str(path) ,str(file_path) )
-            os.remove(path)
+            shutil.move(str(path) ,str(file_path) , shutil.copy)
 
         except:
             logger.sendToLog('Persepolis can not move file', "ERROR")

--- a/persepolis/scripts/download.py
+++ b/persepolis/scripts/download.py
@@ -533,7 +533,7 @@ def downloadCompleteAction(parent, path, download_path, file_name, file_size):
             # move the file to the download folder
             try:
                 # use shutil.copy instead of the default copy2
-                shutil.move(str(path) ,str(file_path) , shutil.copy)
+                shutil.move(str(path) ,str(file_path) ,shutil.copy )
 
             except:
                 logger.sendToLog('Persepolis can not move file', "ERROR")
@@ -550,7 +550,7 @@ def downloadCompleteAction(parent, path, download_path, file_name, file_size):
     else:
         # move the file to the download folder
         try:
-            shutil.move(str(path) ,str(file_path) , shutil.copy)
+            shutil.move(str(path) ,str(file_path) ,shutil.copy )
 
         except:
             logger.sendToLog('Persepolis can not move file', "ERROR")


### PR DESCRIPTION
According to the docs here: https://docs.python.org/3/library/shutil.html, shutil.move is basically shutil.copy2(src, dst) and then os.remove(src), but if the destination is on the same filesystem as the source, then os.rename() is used. In this case shutil.move would reduce the overhead of copying and removing the source file.