### PR TITLE
Fix adding persepolis to startup when ~/.config/autostart doesn't exist

### DIFF
--- a/persepolis/scripts/startup.py
+++ b/persepolis/scripts/startup.py
@@ -98,7 +98,7 @@ StartupWMClass=persepolis-download-Manager
                 home_address + "/.config/autostart/persepolis.desktop", 'w+')
             startupfile.write(entry)
             os.chmod(home_address +
-                     "/.config/.autostart/persepolis.desktop", 0o644)
+                     "/.config/autostart/persepolis.desktop", 0o644)
     # check if it is mac
     elif os_type == "Darwin":
         # OS X

--- a/persepolis/scripts/startup.py
+++ b/persepolis/scripts/startup.py
@@ -87,18 +87,13 @@ StartupWMClass=persepolis-download-Manager
 '''
 
         # check if the autostart directry exists & create entry
-        if os.path.exists(home_address + "/.config/autostart"):
-            startupfile = open(
-                home_address + "/.config/autostart/persepolis.desktop", 'w+')
-            startupfile.write(entry)
-            os.chmod(home_address + "/.config/autostart/persepolis.desktop", 0o644)
         if not os.path.exists(home_address + "/.config/autostart"):
             os.makedirs(home_address + "/.config/autostart", 0o755)
-            startupfile = open(
-                home_address + "/.config/autostart/persepolis.desktop", 'w+')
-            startupfile.write(entry)
-            os.chmod(home_address +
-                     "/.config/autostart/persepolis.desktop", 0o644)
+        startupfile = open(
+            home_address + "/.config/autostart/persepolis.desktop", 'w+')
+        startupfile.write(entry)
+        os.chmod(home_address +
+                 "/.config/autostart/persepolis.desktop", 0o644)
     # check if it is mac
     elif os_type == "Darwin":
         # OS X


### PR DESCRIPTION
Fix referencing `~/.config/.autostart` instead of `~/.config/autostart`
(https://bugzilla.redhat.com/show_bug.cgi?id=1535604)

Small cleanup (remove duplicate code)