### PR TITLE
change x close button action to minizing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ build/
 persepolis.egg-info/
 man/persepolis.1.gz
 .idea/
+.mypy_cache

--- a/persepolis/gui/mainwindow_ui.py
+++ b/persepolis/gui/mainwindow_ui.py
@@ -568,9 +568,9 @@ class MainWindow_Ui(QMainWindow):
 
         # exitAction
         self.exitAction = QAction(QIcon(icons + 'exit'), QCoreApplication.translate("mainwindow_ui_tr", 'Exit'), self,
-                                  statusTip=QCoreApplication.translate("mainwindow_ui_tr", "Exit"), triggered=self.closeEvent)
+                                  statusTip=QCoreApplication.translate("mainwindow_ui_tr", "Exit"), triggered=self.closeAction)
 
-        self.exitAction_shortcut = QShortcut(self.persepolis_setting.value('quit_shortcut'), self, self.closeEvent)
+        self.exitAction_shortcut = QShortcut(self.persepolis_setting.value('quit_shortcut'), self, self.closeAction)
 
         fileMenu.addAction(self.exitAction)
 

--- a/persepolis/scripts/mainwindow.py
+++ b/persepolis/scripts/mainwindow.py
@@ -2311,6 +2311,11 @@ class MainWindow(MainWindow_Ui):
 # close event
 # when user closes application then this method is called
     def closeEvent(self, event=None):
+        #set close event just for minimizing to tray
+        pass
+
+#close application actions is in this method (to close program completely this method must call)
+    def closeAction(self, event):
         # save window size  and position
         self.persepolis_setting.setValue('MainWindow/size', self.size())
         self.persepolis_setting.setValue('MainWindow/position', self.pos())


### PR DESCRIPTION
I change the x close button action to minimizing into tray. Now, the program exit just by Exit button on the top of app icons and if a user accidentally clicks on the close button, he/she can still use Persepolis.
you can see changes by executing the file in `test/` folder.
I did this change on `Manjaro Linux`. 
