### PR TITLE
[Feature]: Add 'Remember Download Path'

### DIFF
--- a/persepolis/gui/addlink_ui.py
+++ b/persepolis/gui/addlink_ui.py
@@ -228,6 +228,9 @@ class AddLinkWindow_Ui(QWidget):
         gridLayout_3.addWidget(self.folder_pushButton, 3, 0, 1, 1)
         self.folder_pushButton.setIcon(QIcon(icons + 'folder'))
 
+        self.folder_checkBox = QCheckBox(self.folder_frame)
+        gridLayout_3.addWidget(self.folder_checkBox)
+
         self.folder_label = QLabel(self.folder_frame)
         self.folder_label.setAlignment(QtCore.Qt.AlignCenter)
         gridLayout_3.addWidget(self.folder_label, 1, 0, 1, 1)
@@ -420,6 +423,7 @@ class AddLinkWindow_Ui(QWidget):
         self.download_pass_label.setText(QCoreApplication.translate("addlink_ui_tr", "Download PassWord: "))
 
         self.folder_pushButton.setText(QCoreApplication.translate("addlink_ui_tr", "Change Download Folder"))
+        self.folder_checkBox.setText(QCoreApplication.translate("addlink_ui_tr", "Remember this path"))
         self.folder_label.setText(QCoreApplication.translate("addlink_ui_tr", "Download Folder: "))
 
         self.start_checkBox.setText(QCoreApplication.translate("addlink_ui_tr", "Start Time"))

--- a/persepolis/gui/text_queue_ui.py
+++ b/persepolis/gui/text_queue_ui.py
@@ -184,6 +184,9 @@ class TextQueue_Ui(QWidget):
         folder_gridLayout.addWidget(self.folder_pushButton, 3, 0, 1, 1)
         self.folder_pushButton.setIcon(QIcon(icons + 'folder'))
 
+        self.folder_checkBox = QCheckBox(self.folder_frame)
+        folder_gridLayout.addWidget(self.folder_checkBox)
+
         self.folder_label = QLabel(self.folder_frame)
         self.folder_label.setAlignment(Qt.AlignCenter)
         folder_gridLayout.addWidget(self.folder_label, 1, 0, 1, 1)
@@ -283,6 +286,7 @@ class TextQueue_Ui(QWidget):
         self.download_pass_label.setText(QCoreApplication.translate("text_ui_tr", "Download PassWord: "))
 
         self.folder_pushButton.setText(QCoreApplication.translate("text_ui_tr", "Change Download Folder"))
+        self.folder_checkBox.setText(QCoreApplication.translate("addlink_ui_tr", "Remember this path"))
         self.folder_label.setText(QCoreApplication.translate("text_ui_tr", "Download Folder: "))
 
         self.limit_checkBox.setText(QCoreApplication.translate("text_ui_tr", "Limit Speed"))

--- a/persepolis/scripts/addlink.py
+++ b/persepolis/scripts/addlink.py
@@ -342,6 +342,11 @@ class AddLinkWindow(AddLinkWindow_Ui):
         self.persepolis_setting.setValue(
             'add_link_initialization/download_user', self.download_user_lineEdit.text())
 
+        # Check 'Remember path' and change default path if needed
+        if self.folder_checkBox.isChecked() == True:
+            self.persepolis_setting.setValue(
+                'settings/download_path', self.download_folder_lineEdit.text())
+
         # get proxy information
         if not(self.proxy_checkBox.isChecked()):
             ip = None

--- a/persepolis/scripts/properties.py
+++ b/persepolis/scripts/properties.py
@@ -341,6 +341,11 @@ class PropertiesWindow(AddLinkWindow_Ui):
             self.end_checkBox.setEnabled(True)
 
     def okButtonPressed(self, button):
+        # write user's new inputs in persepolis_setting for next time if needed
+        if self.folder_checkBox.isChecked() == True:
+            self.persepolis_setting.setValue(
+                'settings/download_path', self.download_folder_lineEdit.text())
+
         if not(self.proxy_checkBox.isChecked()):
             ip = None
             port = None

--- a/persepolis/scripts/text_queue.py
+++ b/persepolis/scripts/text_queue.py
@@ -272,6 +272,11 @@ class TextQueue(TextQueue_Ui):
         self.persepolis_setting.setValue(
             'add_link_initialization/download_user', self.download_user_lineEdit.text())
 
+        # Check 'Remember path' and change default path if needed
+        if self.folder_checkBox.isChecked() == True:
+            self.persepolis_setting.setValue(
+                'settings/download_path', self.download_folder_lineEdit.text())
+
         if not(self.proxy_checkBox.isChecked()):
             ip = None
             port = None


### PR DESCRIPTION
Related to #627, I made some changes that let you to **remember download path**.
This works on `addLink`, `properties` and `textQueue` windows.
It's as shown below:

![Screenshot](https://user-images.githubusercontent.com/31338382/65585658-ae5a9480-df8f-11e9-9286-604c1e918282.png)


Any idea? :)