### PR TITLE
fix-typo - comments only

### DIFF
--- a/persepolis/gui/mainwindow_ui.py
+++ b/persepolis/gui/mainwindow_ui.py
@@ -183,7 +183,7 @@ class CategoryTreeView(QTreeView):
         # creating context menu
         self.category_tree_menu = QMenu(self)
 
-        # connecting actication  event
+        # connecting activation  event
         self.activated.connect(parent.categoryTreeSelected)
         self.pressed.connect(parent.categoryTreeSelected)
 
@@ -394,7 +394,7 @@ class MainWindow_Ui(QMainWindow):
         self.download_table.setEditTriggers(QAbstractItemView.NoEditTriggers)
         self.download_table.verticalHeader().hide()
 
-        # hide gid and download dictioanry section
+        # hide gid and download directory section
         self.download_table.setColumnHidden(8, True)
         self.download_table.setColumnHidden(9, True)
 

--- a/persepolis/gui/mainwindow_ui.py
+++ b/persepolis/gui/mainwindow_ui.py
@@ -394,7 +394,7 @@ class MainWindow_Ui(QMainWindow):
         self.download_table.setEditTriggers(QAbstractItemView.NoEditTriggers)
         self.download_table.verticalHeader().hide()
 
-        # hide gid and link column
+        # hide column of GID and column of link.
         self.download_table.setColumnHidden(8, True)
         self.download_table.setColumnHidden(9, True)
 

--- a/persepolis/gui/mainwindow_ui.py
+++ b/persepolis/gui/mainwindow_ui.py
@@ -394,7 +394,7 @@ class MainWindow_Ui(QMainWindow):
         self.download_table.setEditTriggers(QAbstractItemView.NoEditTriggers)
         self.download_table.verticalHeader().hide()
 
-        # hide gid and download directory section
+        # hide gid and link column
         self.download_table.setColumnHidden(8, True)
         self.download_table.setColumnHidden(9, True)
 

--- a/persepolis/scripts/addlink.py
+++ b/persepolis/scripts/addlink.py
@@ -329,7 +329,7 @@ class AddLinkWindow(AddLinkWindow_Ui):
             self.end_checkBox.setEnabled(True)
 
     def okButtonPressed(self, button, download_later):
-        # user committed information by pressing ok_pushButton, so get information
+        # user submitted information by pressing ok_pushButton, so get information
         # from AddLinkWindow and return them to the mainwindow with callback!
 
         # write user's new inputs in persepolis_setting for next time :)

--- a/persepolis/scripts/addlink.py
+++ b/persepolis/scripts/addlink.py
@@ -145,7 +145,7 @@ class AddLinkWindow(AddLinkWindow_Ui):
         # connect folder_pushButton
         self.folder_pushButton.clicked.connect(self.changeFolder)
 
-        # connect OK and canel download_later button ->
+        # connect OK and cancel download_later button ->
         self.cancel_pushButton.clicked.connect(self.close)
         self.ok_pushButton.clicked.connect(partial(
             self.okButtonPressed, download_later=False))
@@ -329,7 +329,7 @@ class AddLinkWindow(AddLinkWindow_Ui):
             self.end_checkBox.setEnabled(True)
 
     def okButtonPressed(self, button, download_later):
-        # user commited information by pressing ok_pushButton, so get information
+        # user committed information by pressing ok_pushButton, so get information
         # from AddLinkWindow and return them to the mainwindow with callback!
 
         # write user's new inputs in persepolis_setting for next time :)

--- a/persepolis/scripts/browser_plugin_queue.py
+++ b/persepolis/scripts/browser_plugin_queue.py
@@ -157,7 +157,7 @@ class BrowserPluginQueue(TextQueue_Ui):
 # connect folder_pushButton
         self.folder_pushButton.clicked.connect(self.changeFolder)
 
-# connect OK and canel button
+# connect OK and cancel button
 
         self.cancel_pushButton.clicked.connect(self.close)
         self.ok_pushButton.clicked.connect(self.okButtonPressed)
@@ -197,7 +197,7 @@ class BrowserPluginQueue(TextQueue_Ui):
             item = self.links_table.item(i, 0)
             item.setCheckState(Qt.Checked)
 
-# this method uncheckes all check boxes
+# this method unchecks all check boxes
     def deselectAll(self, button):
         for i in range(self.links_table.rowCount()):
             item = self.links_table.item(i, 0)

--- a/persepolis/scripts/check_proxy.py
+++ b/persepolis/scripts/check_proxy.py
@@ -171,7 +171,7 @@ def getProxy():
             key_is_available = True
 
     if not key_is_available and socks_proxy:
-        # all print just for debugung
+        # all print just for debugging
         socks_message = "persepolis and aria2 don't support socks\n\
         you must convert socks proxy to http proxy.\n\
         Please read this for more help:\n\

--- a/persepolis/scripts/compatibility.py
+++ b/persepolis/scripts/compatibility.py
@@ -45,7 +45,7 @@ category_folder = os.path.join(config_folder, 'category_folder')
 # time,limit speed , ...)
 queue_info_folder = os.path.join(config_folder, "queue_info")
 
-# single_downloads_list_file contains gid of non categorised downloads
+# single_downloads_list_file contains gid of non categorized downloads
 single_downloads_list_file = os.path.join(category_folder, "Single Downloads")
 
 

--- a/persepolis/scripts/data_base.py
+++ b/persepolis/scripts/data_base.py
@@ -46,7 +46,7 @@ class TempDB():
         self.lock = False
 
     # this method locks data base.
-    # this is pervent accessing data base simoltaneously.
+    # this is pervent accessing data base simultaneously.
     def lockCursor(self):
         while self.lock:
             rand_float = random.uniform(0, 0.5)
@@ -236,8 +236,8 @@ class PluginsDB():
         # create a lock for data base
         self.lock = False
 
-    # this method locls data base.
-    # this is pervent accessing data base simoltaneously.
+    # this method locks data base.
+    # this is pervent accessing data base simultaneously.
     def lockCursor(self):
         while self.lock:
             rand_float = random.uniform(0, 0.5)
@@ -371,8 +371,8 @@ class PersepolisDB():
         # Create a lock for data base
         self.lock = False
 
-    # this method locls data base.
-    # this is pervent accessing data base simoltaneously.
+    # this method locks data base.
+    # this is pervent accessing data base simultaneously.
     def lockCursor(self):
 
         while self.lock:
@@ -589,7 +589,7 @@ class PersepolisDB():
                 category_gid_list.append(gid)
                 all_downloads_gid_list.append(gid)
 
-            # updata category_db_table
+            # update category_db_table
             self.updateCategoryTable([all_downloads_dict])
             self.updateCategoryTable([category_dict])
 
@@ -749,7 +749,7 @@ class PersepolisDB():
 
         return downloads_dict
 
-    # this method checks existance of a link in addlink_db_table
+    # this method checks existence of a link in addlink_db_table
 
     def searchLinkInAddLinkTable(self, link):
         # lock data base
@@ -1014,7 +1014,7 @@ class PersepolisDB():
 
     def updateVideoFinderTable(self, list):
 
-        # locak data base
+        # lock data base
         self.lockCursor()
 
         keys_list = ['video_gid',

--- a/persepolis/scripts/download.py
+++ b/persepolis/scripts/download.py
@@ -124,7 +124,7 @@ def startAria():
     return answer
 
 # check aria2 release version . Persepolis uses this function to
-# check that aria2 RPC conection is available or not.
+# check that aria2 RPC connection is available or not.
 
 
 def aria2Version():
@@ -351,7 +351,7 @@ def tellStatus(gid, parent):
     if (converted_info_dict['status'] == "complete"):
         file_name = converted_info_dict['file_name']
 
-        # find user prefered download_path from addlink_db_table in data_base
+        # find user preferred download_path from addlink_db_table in data_base
         add_link_dictionary = parent.persepolis_db.searchGidInAddLinkTable(gid)
 
         persepolis_setting.sync()
@@ -391,7 +391,7 @@ def tellStatus(gid, parent):
         add_link_dictionary['download_path'] = file_path
         parent.persepolis_db.updateAddLinkTable([add_link_dictionary])
 
-# if an error occured!
+# if an error occurred!
     if (converted_info_dict['status'] == "error"):
         # add errorMessage to converted_info_dict
         converted_info_dict['error'] = str(download_status['errorMessage'])
@@ -689,8 +689,8 @@ def downloadStop(gid, parent):
     # if status in not "scheduled" so stop request must be sended to aria2.
     if status != 'scheduled':
         try:
-            # send remove download request to aira2.
-            # see aria2 documentation for more informations.
+            # send remove download request to aria2.
+            # see aria2 documentation for more information.
             answer = server.aria2.remove(gid)
             if status == 'downloading':
                 server.aria2.removeDownloadResult(gid)
@@ -721,7 +721,7 @@ def downloadStop(gid, parent):
 def downloadPause(gid):
     # see aria2 documentation for more information
 
-    # send pause request to aira2 .
+    # send pause request to aria2 .
     try:
         answer = server.aria2.pause(gid)
     except:
@@ -825,7 +825,7 @@ def startTime(start_time, gid, parent):
 
     status = 'scheduled'
 
-  # this loop is countinuing until download time arrival!
+  # this loop is continuing until download time arrival!
     while sigma_start != sigma_now:
         time.sleep(2.1)
         sigma_now = nowTime()
@@ -835,7 +835,7 @@ def startTime(start_time, gid, parent):
         data_base_download_status = dict['status']
 
         # if data_base_download_status = stopped >> it means that user
-        # canceled download , and loop must be breaked!
+        # canceled download and loop must break!
         if data_base_download_status == 'stopped':
             status = 'stopped'
             break

--- a/persepolis/scripts/mainwindow.py
+++ b/persepolis/scripts/mainwindow.py
@@ -55,7 +55,7 @@ try:
     from persepolis.scripts.video_finder_addlink import VideoFinderAddLink
     youtube_dl_is_installed = True
 except ModuleNotFoundError:
-    # if youtube_dl madule is not installed:
+    # if youtube_dl module is not installed:
     logger.sendToLog(
         "youtube_dl is not installed.", "ERROR")
     youtube_dl_is_installed = False
@@ -269,7 +269,7 @@ class StartAria2Thread(QThread):
         self.ARIA2RESPONDSIGNAL.emit(signal_str)
 
 
-# This thread checking that which row in download_table highlited by user
+# This thread checking that which row in download_table highlighted by user
 class CheckSelectedRowThread(QThread):
     CHECKSELECTEDROWSIGNAL = pyqtSignal()
 
@@ -320,9 +320,9 @@ class CheckDownloadInfoThread(QThread):
                 sleep(0.2)
                 # if checking_flag is equal to 1, it means that user pressed
                 # remove or delete button . so checking download information
-                # must stop until removing is done! It avoids possiblity of crashing!
+                # must stop until removing is done! It avoids possibility of crashing!
                 if checking_flag == 1:
-                    # Ok loop is stoped!
+                    # Ok loop is stopped!
                     checking_flag = 2
 
                     # check that when job is done!
@@ -345,13 +345,13 @@ class CheckDownloadInfoThread(QThread):
                 try:
                     for gid in active_gid_list:
 
-                        # if gid not in gid_list, so download is completed or stopped or error occured!
+                        # if gid not in gid_list, so download is completed or stopped or error occurred!
                         # because aria2 returns active downloads status with tellActive function in download.py file.
                         # and complete or stopped or errored downloads are not active downloads.
                         # so we must get download information with tellStatus function.
                         # see download.py file (tellStatus and tellActive functions) for more information.
                         # if aria doesn't not return download information with tellStatus and tellActive,
-                        # then perhaps some error occured.so download information must be in data_base.
+                        # then perhaps some error occurred.so download information must be in data_base.
                         if gid not in gid_list:
 
                             returned_dict = download.tellStatus(gid, self.parent)
@@ -382,7 +382,7 @@ class CheckDownloadInfoThread(QThread):
                     else:
                         update_data_base_counter = update_data_base_counter + 1
 
-                    # updat data base!
+                    # update data base!
                     if update_data_base:
                         self.parent.persepolis_db.updateDownloadTable(download_status_list)
 
@@ -391,7 +391,7 @@ class CheckDownloadInfoThread(QThread):
                         update_data_base_counter = -1
 
                 except:
-                    # continue the loop if any error occured.
+                    # continue the loop if any error occurred.
                     self.reconnectAria()
                     continue
 
@@ -423,7 +423,7 @@ class CheckDownloadInfoThread(QThread):
 
 # SpiderThread calls spider in spider.py .
 # spider finds file size and file name of download file .
-# spider works similiar to spider in wget.
+# spider works similar to spider in wget.
 class SpiderThread(QThread):
     SPIDERSIGNAL = pyqtSignal(dict)
 
@@ -472,7 +472,7 @@ class DownloadLink(QThread):
             self.parent.temp_db.updateSingleTable(dictionary)
 
         # if request is not successful then persepolis is checking rpc
-        # connection whith download.aria2Version() function
+        # connection with download.aria2Version() function
         answer = download.downloadAria(self.gid, self.parent)
         if not(answer):
             version_answer = download.aria2Version()
@@ -480,7 +480,7 @@ class DownloadLink(QThread):
             if version_answer == 'did not respond':
                 self.ARIA2NOTRESPOND.emit()
 
-# Persepolis download audio and video seperatly and the muxing them :)
+# Persepolis download audio and video separately and the muxing them :)
 # VideoFinder do this duty for Persepolis.
 # see data_base.py for understanding the code
 # we have video_finder_db_table in data base. it's contains some items that helps
@@ -559,7 +559,7 @@ class VideoFinder(QThread):
 
             # check the download status
             # continue loop and check the download status
-            # if checking == 'no' >> problem occured and downloading canceled.
+            # if checking == 'no' >> problem occurred and downloading canceled.
             while self.video_completed != 'yes' and self.checking == 'yes':
 
                 sleep(1)
@@ -588,7 +588,7 @@ class VideoFinder(QThread):
 
                 # check the download status
                 # continue loop and check the download status
-                # if checking == 'no' >> problem occured and downloading canceled.
+                # if checking == 'no' >> problem occurred and downloading canceled.
                 while self.audio_completed != 'yes' and self.checking == 'yes':
                     sleep(1)
 
@@ -655,7 +655,7 @@ class VideoFinder(QThread):
 
 # this thread is managing queue and sending download request to aria2
 class Queue(QThread):
-    # this signal emited when download status of queue changes to stop
+    # this signal emitted when download status of queue changes to stop
     REFRESHTOOLBARSIGNAL = pyqtSignal(str)
 
     def __init__(self, category, start_time, end_time, parent):
@@ -679,7 +679,7 @@ class Queue(QThread):
         video_finder_list = []
 
         # queue repeats 5 times!
-        # and everty time loads queue list again!
+        # and every time loads queue list again!
         # It is helps for checking new downloads in queue
         # and retrying failed downloads.
         for counter in range(5):
@@ -787,7 +787,7 @@ class Queue(QThread):
                     now_time_minute = int(time.strftime("%M"))
                     now_time_second = int(time.strftime("%S"))
 
-                    # add extra minute if we are in seond half of minute
+                    # add extra minute if we are in second half of minute
                     if now_time_second > 30:
                         now_time_minute = now_time_minute + 1
 
@@ -1042,7 +1042,7 @@ class CheckingThread(QThread):
                 # OK! we catch notification! remove show_window_file now!
                 osCommands.remove(show_window_file)
 
-                # emit a singnal to notify MainWindow for showing itself!
+                # emit a signal to notify MainWindow for showing itself!
                 self.SHOWMAINWINDOWSIGNAL.emit()
 
             # It means new browser plugin call is available!
@@ -1054,14 +1054,14 @@ class CheckingThread(QThread):
                 # When checkPluginCall method considered request , then
                 # plugin_links_checked is changed to True
                 plugin_links_checked = False
-                self.CHECKPLUGINDBSIGNAL.emit()  # notifiying that we have browser_plugin request
+                self.CHECKPLUGINDBSIGNAL.emit()  # notifying that we have browser_plugin request
                 while plugin_links_checked != True:  # wait for persepolis consideration!
                     sleep(0.5)
 
 
 # if checking_flag is equal to 1, it means that user pressed remove or delete button or ... . so checking download information must be stopped until job is done!
 # this thread checks checking_flag and when checking_flag changes to 2
-# QTABLEREADY signal is emmited
+# QTABLEREADY signal is emitted
 class WaitThread(QThread):
     QTABLEREADY = pyqtSignal()
 
@@ -1106,7 +1106,7 @@ class ShutDownThread(QThread):
 
 
 # this thread is keeping system awake! because if system sleeps , then internet connection is disconnected!
-# stxariategy is simple! a loop is checking mouse position every 20 seconds.
+# strategy is simple! a loop is checking mouse position every 20 seconds.
 # if mouse position didn't change, cursor is moved by QCursor.setPos() (see keepAwake method) ! so this is keeping system awake!
 #
 class KeepAwakeThread(QThread):
@@ -1531,7 +1531,7 @@ class MainWindow(MainWindow_Ui):
         if str(self.persepolis_setting.value('MainWindow/maximized')) == 'yes':
             self.showMaximized()
 
-        # get columns visiblity situation from persepolis_setting
+        # get columns visibility situation from persepolis_setting
         if str(self.persepolis_setting.value('settings/column0')) == 'yes':
             self.download_table.setColumnHidden(0, False)
         else:
@@ -1839,7 +1839,7 @@ class MainWindow(MainWindow_Ui):
                     row = i
                     break
 
-            # updat download_table items
+            # update download_table items
             if row != None:
                 update_list = [dict['file_name'], dict['status'], dict['size'], dict['downloaded_size'], dict['percent'],
                                dict['connections'], dict['rate'], dict['estimate_time_left'], dict['gid'], None, None, None, None]
@@ -1980,7 +1980,7 @@ class MainWindow(MainWindow_Ui):
                 status = QCoreApplication.translate("mainwindow_src_ui_tr", "<b>Status</b>: ") + progress_window.status
                 progress_window.status_label.setText(status)
 
-                # active/deactive progress_window buttons according to status
+                # activate/deactivate progress_window buttons according to status
                 if progress_window.status == "downloading":
                     progress_window.resume_pushButton.setEnabled(False)
                     progress_window.stop_pushButton.setEnabled(True)
@@ -2071,7 +2071,7 @@ class MainWindow(MainWindow_Ui):
                     # get shutdown value for this gid from data base
                     shutdown_status = shutdown_dict['shutdown']
 
-                    # if status is complete or error, and user selected "shutdown after downoad" option:
+                    # if status is complete or error, and user selected "shutdown after download" option:
                     if shutdown_status == 'wait':
 
                         # shutdown aria!
@@ -2200,7 +2200,7 @@ class MainWindow(MainWindow_Ui):
         else:
             return rows_list[0]
 
-    # this method actives/deactives QActions according to selected row!
+    # this method activates/deactivates QActions according to selected row!
     def checkSelectedRow(self):
 
         rows_list = self.userSelectedRows()
@@ -2537,7 +2537,7 @@ class MainWindow(MainWindow_Ui):
         elif len(list_of_links):  # we have queue request from browser plugin # Length non-zero
             self.pluginQueue(list_of_links)
 
-    # this method creates an addlinkwindow when user calls Persepolis whith
+    # this method creates an addlinkwindow when user calls Persepolis with
     # browsers plugin (Single Download)
 
     def pluginAddLink(self, add_link_dictionary):
@@ -2668,7 +2668,7 @@ class MainWindow(MainWindow_Ui):
             # open progress window for download.
             self.progressBarOpen(gid)
 
-            # notifiy user
+            # notify user
             # check that download scheduled or not
             if not(add_link_dictionary['start_time']):
                 message = QCoreApplication.translate("mainwindow_src_ui_tr", "Download Starts")
@@ -2942,7 +2942,7 @@ class MainWindow(MainWindow_Ui):
             self.propertiesCallback2(self, add_link_dictionary, gid, category, video_finder_dictionary)
 
     def propertiesCallback2(self, add_link_dictionary, gid, category, video_finder_dictionary=None):
-        # current_category_tree_text is current category that highlited by user
+        # current_category_tree_text is current category that highlighted by user
         # in the left side panel
         current_category_tree_text = str(
             self.category_tree.currentIndex().data())
@@ -3139,12 +3139,12 @@ class MainWindow(MainWindow_Ui):
     # showTray method shows/hides persepolis's icon in system tray icon
 
     def showTray(self, menu):
-        # check if user checed trayAction in menu or not
+        # check if user checked trayAction in menu or not
         if self.trayAction.isChecked():
             # show system_tray_icon
             self.system_tray_icon.show()
 
-            # enabe minimizeAction in menu
+            # enable minimizeAction in menu
             self.minimizeAction.setEnabled(True)
 
             tray_icon = 'yes'
@@ -3252,7 +3252,7 @@ class MainWindow(MainWindow_Ui):
                 if version_answer == 'did not respond':
                     self.aria2Disconnected()
 
-    # this method creats Preferences window
+    # this method creates Preferences window
 
     def openPreferences(self, menu):
         self.preferenceswindow = PreferencesWindow(
@@ -3370,7 +3370,7 @@ class MainWindow(MainWindow_Ui):
     # this method is called when multiple items is selected by user!
     def selectDownloads(self):
 
-        # find highlited item in category_tree
+        # find highlighted item in category_tree
         current_category_tree_text = str(current_category_tree_index.data())
         self.toolBarAndContextMenuItems(current_category_tree_text)
 
@@ -4286,7 +4286,7 @@ class MainWindow(MainWindow_Ui):
             self.text_queue_window_list[len(
                 self.text_queue_window_list) - 1].show()
 
-    # callback of text_queue_window and plugin_queue_window.AboutWindowi
+    # callback of text_queue_window and plugin_queue_window.AboutWindow
     # See importText and pluginQueue method for more information.
     def queueCallback(self, add_link_dictionary_list, category):
 
@@ -4516,7 +4516,7 @@ class MainWindow(MainWindow_Ui):
         self.toolBarAndContextMenuItems(str(current_category_tree_text))
 
     # this method changes toolabr and context menu items when new item
-    # highlited by user in category_tree
+    # highlighted by user in category_tree
     def toolBarAndContextMenuItems(self, category):
 
         # clear toolBar and context menus.
@@ -4931,7 +4931,7 @@ class MainWindow(MainWindow_Ui):
                 # add gid of item to gid_list
                 new_category_gid_list = new_category_gid_list.append(gid)
 
-                # updata category_db_table
+                # update category_db_table
                 self.persepolis_db.updateCategoryTable([new_category_dict])
 
                 # update category in download_table
@@ -4981,7 +4981,7 @@ class MainWindow(MainWindow_Ui):
             self.queue_panel_widget_frame.hide()
             self.queue_panel_show_button.setText(QCoreApplication.translate("mainwindow_src_ui_tr", 'Show options'))
 
-    # this metode is activating after_pushButton whith limit_comboBox changing
+    # this metode is activating after_pushButton with limit_comboBox changing
     def limitComboBoxChanged(self, connect):
         self.limit_pushButton.setEnabled(True)
 
@@ -5154,7 +5154,7 @@ class MainWindow(MainWindow_Ui):
                 self.limit_checkBox.setChecked(True)
 
             else:
-                # disabale limit_frame
+                # disable limit_frame
                 self.limit_checkBox.setChecked(False)
 
             # limit speed
@@ -5311,7 +5311,7 @@ class MainWindow(MainWindow_Ui):
                     new_row_items_list.append(
                         self.download_table.item(new_row, i).text())
 
-                # subtituting
+                # substituting
                 for i in range(13):
                     # old row
                     item = QTableWidgetItem(new_row_items_list[i])
@@ -5341,7 +5341,7 @@ class MainWindow(MainWindow_Ui):
         self.persepolis_db.updateCategoryTable([category_dict])
 
     # this method is called if user pressed moveDownSelected action
-    # this method is subtituting selected download item with lower download item
+    # this method is substituting selected download item with lower download item
     def moveDownSelected(self, menu=None):
 
         global button_pressed_counter
@@ -5365,7 +5365,7 @@ class MainWindow(MainWindow_Ui):
 
     def moveDownSelected2(self):
 
-        # an old row and new row must be subtituted by each other
+        # an old row and new row must be substituted by each other
 
         # find selected rows
         rows_list = self.userSelectedRows()
@@ -5409,7 +5409,7 @@ class MainWindow(MainWindow_Ui):
                     new_row_items_list.append(
                         self.download_table.item(new_row, i).text())
 
-                # subtituting
+                # substituting
                 for i in range(13):
                     # old row
                     item = QTableWidgetItem(new_row_items_list[i])
@@ -5494,7 +5494,7 @@ class MainWindow(MainWindow_Ui):
                            5000, 'fail', parent=self)
 
         # move files with MoveThread
-        # MoveThread is createid to pervent UI freezing.
+        # MoveThread is created to pervent UI freezing.
         move_thread = MoveThread(self, gid_list, new_folder_path)
         self.threadPool.append(move_thread)
         self.threadPool[len(self.threadPool) - 1].start()
@@ -5536,7 +5536,7 @@ class MainWindow(MainWindow_Ui):
                 row = i
                 break
 
-        # updat download_table items
+        # update download_table items
         if row != None:
             update_list = [dict['file_name'], dict['status'], dict['size'], dict['downloaded_size'], dict['percent'],
                            dict['connections'], dict['rate'], dict['estimate_time_left'], dict['gid'], None, None, None, None]
@@ -5727,7 +5727,7 @@ class MainWindow(MainWindow_Ui):
                     self.download_table.setItem(0, j, item)
                     j = j + 1
 
-        # add video_gid and audio_gid to data baose
+        # add video_gid and audio_gid to data base
         dictionary = {'video_gid': add_link_dictionary_list[0]['gid'],
                       'audio_gid': add_link_dictionary_list[1]['gid'],
                       'video_completed': 'no',
@@ -5759,7 +5759,7 @@ class MainWindow(MainWindow_Ui):
             # open progress window for download.
             self.progressBarOpen(dictionary['video_gid'])
 
-            # notifiy user
+            # notify user
             if not(add_link_dictionary_list[0]['start_time']):
                 message = QCoreApplication.translate("mainwindow_src_ui_tr", "Download Starts")
             else:
@@ -5833,7 +5833,7 @@ class MainWindow(MainWindow_Ui):
                     break
 
             # muxing is complete
-            # so remove unuse files
+            # so remove unused files
             # find download path
             audio_add_link_dictionary = self.persepolis_db.searchGidInAddLinkTable(complete_dictionary['audio_gid'])
             video_add_link_dictionary = self.persepolis_db.searchGidInAddLinkTable(complete_dictionary['video_gid'])
@@ -5879,7 +5879,7 @@ class MainWindow(MainWindow_Ui):
                     break
 
             if row != None:
-                # creafe a QTableWidgetItem
+                # create a QTableWidgetItem
                 item = QTableWidgetItem(str(video_download_table_dict['file_name']))
 
                 # set item

--- a/persepolis/scripts/osCommands.py
+++ b/persepolis/scripts/osCommands.py
@@ -166,7 +166,7 @@ def remove(file_path):  # remove file with path of file_path
     if os.path.isfile(file_path):
         try:
             os.remove(file_path)
-            return 'ok'  # function returns  this , if opertation was successful
+            return 'ok'  # function returns  this , if operation was successful
         except:
             return 'cant'  # function returns this , if operation was not successful
     else:
@@ -174,7 +174,7 @@ def remove(file_path):  # remove file with path of file_path
 
 
 def removeDir(folder_path):  # removeDir removes folder : folder_path
-    if os.path.isdir(folder_path):  # check folder_path existance
+    if os.path.isdir(folder_path):  # check folder_path existence
         try:
             shutil.rmtree(folder_path)  # remove folder
             return 'ok'

--- a/persepolis/scripts/persepolis.py
+++ b/persepolis/scripts/persepolis.py
@@ -52,8 +52,8 @@ config_folder = determineConfigFolder()
 persepolis_tmp = os.path.join(config_folder, 'persepolis_tmp')
 
 
-# if lock_file_validation == True >> not another instanse running,
-# else >> another instanse of persepolis is running now.
+# if lock_file_validation == True >> not another instance running,
+# else >> another instance of persepolis is running now.
 global lock_file_validation
 
 if os_type != 'Windows':
@@ -163,8 +163,8 @@ parser.add_argument('--parent-window', action='store', nargs=1,
 parser.add_argument('--version', action='version', version='Persepolis Download Manager 3.2.0')
 
 
-# Clears unwated args ( like args from Browers via NHM )
-# unkown arguments (may sent by browser) will save in unkownargs.
+# Clears unwanted args ( like args from Browers via NHM )
+# unknown arguments (may sent by browser) will save in unknownargs.
 args, unkownargs = parser.parse_known_args()
 
 # if --execute >> yes  >>> persepolis main window  will start.
@@ -309,10 +309,10 @@ else:
 
 
 # when browsers plugin calls persepolis or user runs persepolis by terminal arguments,
-# then persepolis creats a request file in persepolis_tmp folder and link information added to
+# then persepolis creates a request file in persepolis_tmp folder and link information added to
 # plugins_db.db file(see data_base.py for more information).
 # persepolis mainwindow checks persepolis_tmp for plugins request file every 2 seconds (see CheckingThread class in mainwindow.py)
-# when requset received in CheckingThread, a popup window (AddLinkWindow) comes up and window gets additional download information
+# when request received in CheckingThread, a popup window (AddLinkWindow) comes up and window gets additional download information
 # from user (port , proxy , ...) and download starts and request file deleted
 
 if ('link' in add_link_dictionary.keys()):
@@ -397,7 +397,7 @@ def main():
             # write error_message in log file.
             logger.sendToLog('Qt.AA_UseHighDpiPixmaps is not available!', "ERROR")
 
-        # set organization name and domain and apllication name
+        # set organization name and domain and application name
         QCoreApplication.setOrganizationName('persepolis_download_manager')
         QCoreApplication.setApplicationName('persepolis')
 

--- a/persepolis/scripts/play.py
+++ b/persepolis/scripts/play.py
@@ -24,7 +24,7 @@ def playNotification(file):
     # getting user setting from persepolis_setting
     persepolis_setting = QSettings('persepolis_download_manager', 'persepolis')
 
-    # enbling or disabling notification sound in persepolis_setting
+    # enabling or disabling notification sound in persepolis_setting
     enable_notification = str(persepolis_setting.value('settings/sound'))
 
     # volume of notification in persepolis_setting(an integer between 0 to 100)

--- a/persepolis/scripts/progress.py
+++ b/persepolis/scripts/progress.py
@@ -67,7 +67,7 @@ class ProgressWindow(ProgressWindow_Ui):
         if self.translator.load(':/translations/locales/ui_' + locale, 'ts'):
             QCoreApplication.installTranslator(self.translator)
 
-# check if limit speed actived by user or not
+# check if limit speed activated by user or not
         add_link_dictionary = self.parent.persepolis_db.searchGidInAddLinkTable(gid)
 
         limit = str(add_link_dictionary['limit_value'])
@@ -178,7 +178,7 @@ class ProgressWindow(ProgressWindow_Ui):
 
             # check download status is "scheduled" or not!
             if self.status != 'scheduled':
-                # tell aria2 for unlimiting speed
+                # tell aria2 for unlimited speed
                 download.limitSpeed(self.gid, "0")
             else:
                 # update limit value in data_base

--- a/persepolis/scripts/properties.py
+++ b/persepolis/scripts/properties.py
@@ -68,7 +68,7 @@ class PropertiesWindow(AddLinkWindow_Ui):
         self.ok_pushButton.setEnabled(False)
         self.link_lineEdit.textChanged.connect(self.linkLineChanged)
 
-# connect OK and canel button
+# connect OK and cancel button
 
         self.cancel_pushButton.clicked.connect(self.close)
         self.ok_pushButton.clicked.connect(self.okButtonPressed)

--- a/persepolis/scripts/setting.py
+++ b/persepolis/scripts/setting.py
@@ -473,14 +473,14 @@ class PreferencesWindow(Setting_Ui):
             current_color_index = self.color_comboBox.findText(
                 str(self.persepolis_setting.value('color-scheme')))
 
-            # it means user's prefered color_scheme is not valid in color_comboBox.
+            # it means user's preferred color_scheme is not valid in color_comboBox.
             if current_color_index == -1:
                 current_color_index = 0
 
             self.color_comboBox.setCurrentIndex(current_color_index)
 
         self.setDarkLightIcon()
-            
+
     # this method sets dark icons for dark color schemes
     # and light icons for light color schemes.
     def setDarkLightIcon(self, index=None):
@@ -569,7 +569,7 @@ class PreferencesWindow(Setting_Ui):
 
     def fontCheckBoxState(self, checkBox):
 
-        # deactive fontComboBox and font_size_spinBox if font_checkBox not checked!
+        # deactivate fontComboBox and font_size_spinBox if font_checkBox not checked!
         if self.font_checkBox.isChecked():
             self.fontComboBox.setEnabled(True)
             self.font_size_spinBox.setEnabled(True)
@@ -949,13 +949,13 @@ class PreferencesWindow(Setting_Ui):
         if self.startup_checkbox.isChecked():
             self.persepolis_setting.setValue('startup', 'yes')
 
-            if not(startup.checkstartup()):  # checking existance of Persepolis in  system's startup
+            if not(startup.checkstartup()):  # checking existence of Persepolis in  system's startup
 
                 startup.addstartup()  # adding Persepolis to system's startup
         else:
             self.persepolis_setting.setValue('startup', 'no')
 
-            if startup.checkstartup():  # checking existance of Persepolis in  system's startup
+            if startup.checkstartup():  # checking existence of Persepolis in  system's startup
 
                 startup.removestartup()  # removing Persepolis from system's startup
 

--- a/persepolis/scripts/spider.py
+++ b/persepolis/scripts/spider.py
@@ -41,7 +41,7 @@ def spider(add_link_dictionary):
     raw_cookies = add_link_dictionary['load_cookies']
     referer = add_link_dictionary['referer']
 
-    # defin a requests session
+    # define a requests session
     requests_session = requests.Session()
     if ip:
         ip_port = 'http://' + str(ip) + ":" + str(port)

--- a/persepolis/scripts/startup.py
+++ b/persepolis/scripts/startup.py
@@ -88,7 +88,7 @@ Icon=persepolis
 StartupWMClass=persepolis-download-Manager
 '''
 
-        # check if the autostart directry exists & create entry
+        # check if the autostart directory exists & create entry
         if not os.path.exists(home_address + "/.config/autostart"):
             os.makedirs(home_address + "/.config/autostart", 0o755)
         startupfile = open(

--- a/persepolis/scripts/text_queue.py
+++ b/persepolis/scripts/text_queue.py
@@ -157,7 +157,7 @@ class TextQueue(TextQueue_Ui):
         # connect folder_pushButton
         self.folder_pushButton.clicked.connect(self.changeFolder)
 
-        # connect OK and canel button
+        # connect OK and cancel button
         self.cancel_pushButton.clicked.connect(self.close)
         self.ok_pushButton.clicked.connect(self.okButtonPressed)
 
@@ -189,7 +189,7 @@ class TextQueue(TextQueue_Ui):
         self.resize(size)
         self.move(position)
 
-    # this method checkes all check boxes
+    # this method checks all check boxes
     def selectAll(self, button):
         for i in range(self.links_table.rowCount()):
             item = self.links_table.item(i, 0)

--- a/persepolis/scripts/useful_tools.py
+++ b/persepolis/scripts/useful_tools.py
@@ -35,7 +35,7 @@ os_type = platform.system()
 home_address = os.path.expanduser("~")
 
 
-# determine the config folder path base on the oprating system
+# determine the config folder path based on the operating system
 def determineConfigFolder():
     if os_type == 'Linux' or os_type == 'FreeBSD' or os_type == 'OpenBSD':
         config_folder = os.path.join(
@@ -82,7 +82,7 @@ def humanReadbleSize(size, input_type='file_size'):
     else:
         return str(round(size, None)) + ' ' + labels[i]
 
-# this function converts human readble size to byte
+# this function converts human readable size to byte
 
 
 def convertToByte(file_size):
@@ -268,7 +268,7 @@ def muxer(parent, video_finder_dictionary):
     audio_file_path = audio_file_dictionary['download_path']
     final_path = video_finder_dictionary['download_path']
 
-    # caculate final file's size
+    # calculate final file's size
     video_file_size = parent.persepolis_db.searchGidInDownloadTable(video_finder_dictionary['video_gid'])['size']
     audio_file_size = parent.persepolis_db.searchGidInDownloadTable(video_finder_dictionary['audio_gid'])['size']
 

--- a/persepolis/scripts/video_finder_addlink.py
+++ b/persepolis/scripts/video_finder_addlink.py
@@ -619,7 +619,7 @@ class VideoFinderAddLink(AddLinkWindow):
 
             elif self.video_format_selection_comboBox.currentText() == 'No video' and self.audio_format_selection_comboBox.currentText() == 'No audio':
 
-                # no video or audio is selected! REALLY?!. user is DRUNK! close the window! :))
+                # no video and audio is selected! REALLY?!. user is DRUNK! close the window! :))
                 self.close()
         else:
             if self.media_comboBox.currentText() == 'Best quality':

--- a/persepolis/scripts/video_finder_addlink.py
+++ b/persepolis/scripts/video_finder_addlink.py
@@ -590,7 +590,7 @@ class VideoFinderAddLink(AddLinkWindow):
                 options[i] = None
         return options
 
-    # user committed information by pressing ok_pushButton, so get information
+    # user submitted information by pressing ok_pushButton, so get information
     # from VideoFinderAddLink window and return them to the mainwindow with callback!
     def okButtonPressed(self, button, download_later):
 

--- a/persepolis/scripts/video_finder_addlink.py
+++ b/persepolis/scripts/video_finder_addlink.py
@@ -512,7 +512,7 @@ class VideoFinderAddLink(AddLinkWindow):
                 self.ok_pushButton.setEnabled(True)
                 self.download_later_pushButton.setEnabled(True)
 
-                # if we have no options for seperate audio and video, then hide advanced_format_selection...
+                # if we have no options for separate audio and video, then hide advanced_format_selection...
                 if len(self.no_audio_list) == 0 and len(self.no_video_list) == 0:
                     self.advanced_format_selection_checkBox.hide()
                     self.advanced_format_selection_frame.hide()
@@ -590,12 +590,12 @@ class VideoFinderAddLink(AddLinkWindow):
                 options[i] = None
         return options
 
-    # user commited information by pressing ok_pushButton, so get information
+    # user committed information by pressing ok_pushButton, so get information
     # from VideoFinderAddLink window and return them to the mainwindow with callback!
     def okButtonPressed(self, button, download_later):
 
         link_list = []
-        # seperate audio format and video format is selected.
+        # separate audio format and video format is selected.
         if self.advanced_format_selection_checkBox.isChecked():
 
             if self.video_format_selection_comboBox.currentText() == 'No video' and self.audio_format_selection_comboBox.currentText() != 'No audio':
@@ -619,7 +619,7 @@ class VideoFinderAddLink(AddLinkWindow):
 
             elif self.video_format_selection_comboBox.currentText() == 'No video' and self.audio_format_selection_comboBox.currentText() == 'No audio':
 
-                # no video and no video selected! REALY?!. user is DRUNK! close the window! :))
+                # no video or audio is selected! REALLY?!. user is DRUNK! close the window! :))
                 self.close()
         else:
             if self.media_comboBox.currentText() == 'Best quality':
@@ -714,7 +714,7 @@ class VideoFinderAddLink(AddLinkWindow):
         else:
             extension = str(self.extension_label.text())
 
-        # did user select seperate audio and video?
+        # did user select separate audio and video?
         if len(link_list) == 2:
             video_name = name + extension
             audio_name = name + '.' + \

--- a/persepolis/scripts/video_finder_progress.py
+++ b/persepolis/scripts/video_finder_progress.py
@@ -48,7 +48,7 @@ class VideoFinderProgressWindow(VideoFinderProgressWindow_Ui):
         self.gid_list = gid_list
 
         # this variable can be changed by checkDownloadInfo method in mainwindow.py
-        # self.gid defines that wich gid is downloaded.
+        # self.gid defines that which gid is downloaded.
         self.gid = gid_list[0]
 
         # this variable used as category name in ShutDownThread
@@ -76,7 +76,7 @@ class VideoFinderProgressWindow(VideoFinderProgressWindow_Ui):
         if self.translator.load(':/translations/locales/ui_' + locale, 'ts'):
             QCoreApplication.installTranslator(self.translator)
 
-        # check if limit speed actived by user or not
+        # check if limit speed is activated by user or not
         add_link_dictionary = self.parent.persepolis_db.searchGidInAddLinkTable(gid_list[0])
 
         limit = str(add_link_dictionary['limit_value'])
@@ -193,7 +193,7 @@ class VideoFinderProgressWindow(VideoFinderProgressWindow_Ui):
 
                 if status != 'scheduled':
 
-                    # tell aria2 for unlimiting speed
+                    # tell aria2 for unlimited speed
                     download.limitSpeed(gid, "0")
 
                 else:
@@ -290,6 +290,7 @@ class VideoFinderProgressWindow(VideoFinderProgressWindow_Ui):
 
         else:
             # for Windows
+            # TODO: gid_list -> self.gid_list
             for gid in gid_list:
                 shutdown_enable = ShutDownThread(self.parent, self.video_finder_plus_gid)
                 self.parent.threadPool.append(shutdown_enable)


### PR DESCRIPTION
Hi.
I was tracking a bug in vscode. I had spell check and pylint enabled. Spell check hinted some typos.I checked every file and found some typos in:

- comments
- logger messages
- variable, methods, ... names

This PR just fixes comments and no actual code is changed.