### PR TITLE
fix firefox issue in windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ persepolis.egg-info/
 man/persepolis.1.gz
 .idea/
 .mypy_cache
+

--- a/persepolis/msghost.py
+++ b/persepolis/msghost.py
@@ -1,6 +1,6 @@
 # Windows message host middle man. 
 # Use pyinstaller to create a single-file executable from this file.
-# Then place it in installation root directory (usually C:\Program Files\Persepolis Download Manager\)
+# Then place it in installation root directory.
 
 import os
 import sys
@@ -14,33 +14,29 @@ from subprocess import (
 )
 
 
-# windows flags to create a detached and independent child process that lives after its parent dies.
+
 creationflags = CREATE_BREAKAWAY_FROM_JOB | DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP
 
 cwd = sys.argv[0]
 current_directory = os.path.dirname(cwd)
 persepolis_path = os.path.join(current_directory, "Persepolis Download Manager.exe")
 
-## TODO: fix this temporary solution
-## I can not understand the way redirection works in windows.
+## TODO: this fix is a temporary solution
 ## Both firefox and Chrome messages from stdin will be parsed successfully in this file.
 ## But if you skip parsing and redirect them to pdm by Popen(...,stdin=None,...):
 ## - message from firefox will be redirected to persepolis with no problem.
-## - message from Chrome will be dropped.
-## As a temporary solution, message is parsed here and saved to a binary file.
-## Then file is passed to pdm.
-home_address = str(os.path.expanduser("~"))
-nhm_request = os.path.join(
-    home_address, r'AppData\Local\persepolis_download_manager\nhm_request.bin')
-raw_size = sys.stdin.buffer.read(4)  
+## - message from Chrome will be dropped and pdm will see no message.
+## As a temporary solution, message is parsed here and saved to a binary object.
+## Then this binary object is passed to pdm.
+
+raw_size = sys.stdin.buffer.read(4) 
 length = struct.unpack('@I', raw_size)[0]
 raw_data = sys.stdin.buffer.read(length)
-with open(nhm_request, "w+b") as msg:
-    received_message = struct.pack("=I{}s".format(length), length, raw_data)
-    msg.write(received_message)
+received_message = struct.pack("=I{}s".format(length), length, raw_data)
 
-# pass '--nhm' to ensure there will be an unknown arg in parse_args output
+# pass '--nhm' to ensure there will be an unknown arg in parse_args 
 # to trigger parsing NHM messages
 command = [os.path.abspath(persepolis_path), "--nhm"]
-proc = Popen(command, stdin=open(nhm_request, 'r+b'), stderr=PIPE, stdout=PIPE, creationflags=creationflags)
+proc = Popen(command, stdin=PIPE, stderr=PIPE, stdout=PIPE, creationflags=creationflags)
+proc.communicate(input=received_message)
 sys.exit(0)

--- a/persepolis/msghost.py
+++ b/persepolis/msghost.py
@@ -1,6 +1,6 @@
 # Windows message host middle man. 
 # Use pyinstaller to create a single-file executable from this file.
-# Then place it at installation root directory.
+# Then place it in installation root directory (usually C:\Program Files\Persepolis Download Manager\)
 
 import os
 import sys
@@ -14,7 +14,7 @@ from subprocess import (
 )
 
 
-
+# windows flags to create a detached and independent child process that lives after its parent dies.
 creationflags = CREATE_BREAKAWAY_FROM_JOB | DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP
 
 cwd = sys.argv[0]

--- a/persepolis/msghost.py
+++ b/persepolis/msghost.py
@@ -1,0 +1,46 @@
+# Windows message host middle man. 
+# Use pyinstaller to create a single-file executable from this file.
+# Then place it at installation root directory.
+
+import os
+import sys
+import struct
+from subprocess import (
+    Popen,
+    PIPE,
+    DETACHED_PROCESS,
+    CREATE_NEW_PROCESS_GROUP,
+    CREATE_BREAKAWAY_FROM_JOB
+)
+
+
+
+creationflags = CREATE_BREAKAWAY_FROM_JOB | DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP
+
+cwd = sys.argv[0]
+current_directory = os.path.dirname(cwd)
+persepolis_path = os.path.join(current_directory, "Persepolis Download Manager.exe")
+
+## TODO: fix this temporary solution
+## I can not understand the way redirection works in windows.
+## Both firefox and Chrome messages from stdin will be parsed successfully in this file.
+## But if you skip parsing and redirect them to pdm by Popen(...,stdin=None,...):
+## - message from firefox will be redirected to persepolis with no problem.
+## - message from Chrome will be dropped.
+## As a temporary solution, message is parsed here and saved to a binary file.
+## Then file is passed to pdm.
+home_address = str(os.path.expanduser("~"))
+nhm_request = os.path.join(
+    home_address, r'AppData\Local\persepolis_download_manager\nhm_request.bin')
+raw_size = sys.stdin.buffer.read(4)  
+length = struct.unpack('@I', raw_size)[0]
+raw_data = sys.stdin.buffer.read(length)
+with open(nhm_request, "w+b") as msg:
+    received_message = struct.pack("=I{}s".format(length), length, raw_data)
+    msg.write(received_message)
+
+# pass '--nhm' to ensure there will be an unknown arg in parse_args output
+# to trigger parsing NHM messages
+command = [os.path.abspath(persepolis_path), "--nhm"]
+proc = Popen(command, stdin=open(nhm_request, 'r+b'), stderr=PIPE, stdout=PIPE, creationflags=creationflags)
+sys.exit(0)

--- a/persepolis/scripts/browser_integration.py
+++ b/persepolis/scripts/browser_integration.py
@@ -130,9 +130,12 @@ def browserIntegration(browser):
 
         current_directory = os.path.dirname(cwd)
 
-        exec_path = os.path.join(
-            current_directory, 'Persepolis Download Manager.exe')
+        ## for working on editable windows installation use 'msghost.bat' instead
+        exec_path = os.path.join(current_directory, 'msghost.exe')
+        # exec_path = os.path.join(current_directory, 'msghost.bat')
 
+        # to working in editable windows installation, we need absolute path
+        exec_path = os.path.abspath(exec_path)
         # the execution path in json file for Windows must in form of
         # c:\\Users\\...\\Persepolis Download Manager.exe , so we need 2
         # "\" in address
@@ -140,10 +143,10 @@ def browserIntegration(browser):
 
         if browser in BROWSER.CHROME_FAMILY:
             native_message_folder = os.path.join(
-                home_address, 'AppData\Local\persepolis_download_manager', 'chrome')
+                home_address, r'AppData\Local\persepolis_download_manager', 'chrome')
         else:
             native_message_folder = os.path.join(
-                home_address, 'AppData\Local\persepolis_download_manager', 'firefox')
+                home_address, r'AppData\Local\persepolis_download_manager', 'firefox')
 
     # WebExtension native hosts file prototype
     webextension_json_connector = {

--- a/persepolis/scripts/persepolis.py
+++ b/persepolis/scripts/persepolis.py
@@ -186,19 +186,21 @@ browser_plugin_dict = {'link': None,
 # This dirty trick will show Persepolis version when there are unknown args
 # Unknown args are sent by Browsers for NHM
 if args.parent_window or unkownargs:
-
+   
     # Platform specific configuration
     if os_type == OS.WINDOWS:
         # Set the default I/O mode to O_BINARY in windows
         import msvcrt
         msvcrt.setmode(sys.stdin.fileno(), os.O_BINARY)
         msvcrt.setmode(sys.stdout.fileno(), os.O_BINARY)
-
-    # Send message to browsers plugin
-    message = '{"enable": true, "version": "1.85"}'.encode('utf-8')
-    sys.stdout.buffer.write((struct.pack('i', len(message))))
-    sys.stdout.buffer.write(message)
-    sys.stdout.flush()
+    else:
+        # TODO: fix windows error
+        # This section causes an "OSError: [Errno 22] Invalid argument" in windows, skip for now.
+        # Send message to browsers plugin
+        message = '{"enable": true, "version": "1.85"}'.encode('utf-8')
+        sys.stdout.buffer.write((struct.pack('i', len(message))))
+        sys.stdout.buffer.write(message)
+        sys.stdout.flush()
 
     text_length_bytes = sys.stdin.buffer.read(4)
 


### PR DESCRIPTION
This PR adds a `persepolis/msghost.py` as a middle man to transfer messages from browsers to persepolis.  It just affects windows users and has nothing to do with other operating systems.  
It also skips sending a response after getting browser messages (for Windows only). It is not a vital part and I will fix it later.  
After this PR merged, I will update [persepolis-windows-package-build](https://github.com/persepolisdm/persepolis-windows-package-build) and make a PR to adopt this changes.