### PR TITLE
Fix typos and capitalization

### DIFF
--- a/persepolis/gui/addlink_ui.py
+++ b/persepolis/gui/addlink_ui.py
@@ -185,7 +185,7 @@ class AddLinkWindow_Ui(QWidget):
 
         more_options_tab_verticalLayout = QVBoxLayout(self.more_options_tab)
 
-        # download UserName & Password ->
+        # download Username & Password ->
         download_horizontalLayout = QHBoxLayout()
         download_horizontalLayout.setContentsMargins(-1, 10, -1, -1)
 
@@ -400,41 +400,41 @@ class AddLinkWindow_Ui(QWidget):
         self.setLayout(window_verticalLayout)
 
         # labels ->
-        self.setWindowTitle(QCoreApplication.translate("addlink_ui_tr", "Enter Your Link"))
+        self.setWindowTitle(QCoreApplication.translate("addlink_ui_tr", "Add Download Link"))
 
-        self.link_label.setText(QCoreApplication.translate("addlink_ui_tr", "Download Link: "))
+        self.link_label.setText(QCoreApplication.translate("addlink_ui_tr", "Download link: "))
 
         self.add_queue_label.setText(QCoreApplication.translate("addlink_ui_tr", "Add to category: "))
 
-        self.change_name_checkBox.setText(QCoreApplication.translate("addlink_ui_tr", "Change File Name: "))
+        self.change_name_checkBox.setText(QCoreApplication.translate("addlink_ui_tr", "Change file name: "))
 
-        self.detect_proxy_pushButton.setText(QCoreApplication.translate("addlink_ui_tr", "Detect system proxy setting"))
+        self.detect_proxy_pushButton.setText(QCoreApplication.translate("addlink_ui_tr", "Detect System Proxy Settings"))
         self.proxy_checkBox.setText(QCoreApplication.translate("addlink_ui_tr", "Proxy"))
-        self.proxy_pass_label.setText(QCoreApplication.translate("addlink_ui_tr", "Proxy PassWord: "))
+        self.proxy_pass_label.setText(QCoreApplication.translate("addlink_ui_tr", "Proxy password: "))
         self.ip_label.setText(QCoreApplication.translate("addlink_ui_tr", "IP: "))
-        self.proxy_user_label.setText(QCoreApplication.translate("addlink_ui_tr", "Proxy UserName: "))
+        self.proxy_user_label.setText(QCoreApplication.translate("addlink_ui_tr", "Proxy username: "))
         self.port_label.setText(QCoreApplication.translate("addlink_ui_tr", "Port:"))
 
-        self.download_checkBox.setText(QCoreApplication.translate("addlink_ui_tr", "Download UserName and PassWord"))
-        self.download_user_label.setText(QCoreApplication.translate("addlink_ui_tr", "Download UserName: "))
-        self.download_pass_label.setText(QCoreApplication.translate("addlink_ui_tr", "Download PassWord: "))
+        self.download_checkBox.setText(QCoreApplication.translate("addlink_ui_tr", "Download username and password"))
+        self.download_user_label.setText(QCoreApplication.translate("addlink_ui_tr", "Download username: "))
+        self.download_pass_label.setText(QCoreApplication.translate("addlink_ui_tr", "Download password: "))
 
         self.folder_pushButton.setText(QCoreApplication.translate("addlink_ui_tr", "Change Download Folder"))
         self.folder_label.setText(QCoreApplication.translate("addlink_ui_tr", "Download Folder: "))
 
-        self.start_checkBox.setText(QCoreApplication.translate("addlink_ui_tr", "Start Time"))
-        self.end_checkBox.setText(QCoreApplication.translate("addlink_ui_tr", "End Time"))
+        self.start_checkBox.setText(QCoreApplication.translate("addlink_ui_tr", "Start time"))
+        self.end_checkBox.setText(QCoreApplication.translate("addlink_ui_tr", "End time"))
 
-        self.limit_checkBox.setText(QCoreApplication.translate("addlink_ui_tr", "Limit Speed"))
+        self.limit_checkBox.setText(QCoreApplication.translate("addlink_ui_tr", "Limit speed"))
         self.limit_comboBox.setItemText(0, "KiB/s")
         self.limit_comboBox.setItemText(1, "MiB/s")
 
-        self.connections_label.setText(QCoreApplication.translate("addlink_ui_tr", "Number Of Connections:"))
+        self.connections_label.setText(QCoreApplication.translate("addlink_ui_tr", "Number of connections:"))
 
         self.cancel_pushButton.setText(QCoreApplication.translate("addlink_ui_tr", "Cancel"))
         self.ok_pushButton.setText(QCoreApplication.translate("addlink_ui_tr", "OK"))
 
-        self.download_later_pushButton.setText(QCoreApplication.translate("addlink_ui_tr", "Download later"))
+        self.download_later_pushButton.setText(QCoreApplication.translate("addlink_ui_tr", "Download Later"))
 
         self.add_link_tabWidget.setTabText(self.add_link_tabWidget.indexOf(
             self.link_tab), QCoreApplication.translate("addlink_ui_tr", "Link"))

--- a/persepolis/gui/log_window_ui.py
+++ b/persepolis/gui/log_window_ui.py
@@ -89,8 +89,8 @@ class LogWindow_Ui(QWidget):
 # set labels
 
         self.setWindowTitle(QCoreApplication.translate("log_window_ui_tr", 'Persepolis Log'))
-        self.close_pushButton.setText(QCoreApplication.translate("log_window_ui_tr", 'close'))
-        self.copy_log_pushButton.setText(QCoreApplication.translate("log_window_ui_tr", 'Copy selected to clipboard'))
+        self.close_pushButton.setText(QCoreApplication.translate("log_window_ui_tr", 'Close'))
+        self.copy_log_pushButton.setText(QCoreApplication.translate("log_window_ui_tr", 'Copy Selected to Clipboard'))
         self.report_pushButton.setText(QCoreApplication.translate("log_window_ui_tr", "Report Issue"))
-        self.refresh_log_pushButton.setText(QCoreApplication.translate("log_window_ui_tr", 'Refresh log messages'))
-        self.clear_log_pushButton.setText(QCoreApplication.translate("log_window_ui_tr", 'Clear log messages'))
+        self.refresh_log_pushButton.setText(QCoreApplication.translate("log_window_ui_tr", 'Refresh Log Messages'))
+        self.clear_log_pushButton.setText(QCoreApplication.translate("log_window_ui_tr", 'Clear Log Messages'))

--- a/persepolis/gui/mainwindow_ui.py
+++ b/persepolis/gui/mainwindow_ui.py
@@ -399,7 +399,7 @@ class MainWindow_Ui(QMainWindow):
         self.download_table.setColumnHidden(9, True)
 
         download_table_header = [QCoreApplication.translate("mainwindow_ui_tr", 'File Name'), QCoreApplication.translate("mainwindow_ui_tr", 'Status'), QCoreApplication.translate("mainwindow_ui_tr", 'Size'), QCoreApplication.translate("mainwindow_ui_tr", 'Downloaded'), QCoreApplication.translate("mainwindow_ui_tr", 'Percentage'), QCoreApplication.translate("mainwindow_ui_tr", 'Connections'),
-                                 QCoreApplication.translate("mainwindow_ui_tr", 'Transfer rate'), QCoreApplication.translate("mainwindow_ui_tr", 'Estimated time left'), 'Gid', QCoreApplication.translate("mainwindow_ui_tr", 'Link'), QCoreApplication.translate("mainwindow_ui_tr", 'First try date'), QCoreApplication.translate("mainwindow_ui_tr", 'Last try date'), QCoreApplication.translate("mainwindow_ui_tr", 'Category')]
+                                 QCoreApplication.translate("mainwindow_ui_tr", 'Transfer Rate'), QCoreApplication.translate("mainwindow_ui_tr", 'Estimated Time Left'), 'Gid', QCoreApplication.translate("mainwindow_ui_tr", 'Link'), QCoreApplication.translate("mainwindow_ui_tr", 'First Try Date'), QCoreApplication.translate("mainwindow_ui_tr", 'Last Try Date'), QCoreApplication.translate("mainwindow_ui_tr", 'Category')]
 
         self.download_table.setHorizontalHeaderLabels(download_table_header)
 
@@ -486,7 +486,7 @@ class MainWindow_Ui(QMainWindow):
         self.persepolis_setting.beginGroup('settings/shortcuts')
 
         # videoFinderAddLinkAction
-        self.videoFinderAddLinkAction = QAction(QIcon(icons + 'video_finder'), QCoreApplication.translate("mainwindow_ui_tr", 'Find Video Links'), self, statusTip=QCoreApplication.translate("mainwindow_ui_tr", 'Download video or audio from Youtube, Vimeo, etc...'),
+        self.videoFinderAddLinkAction = QAction(QIcon(icons + 'video_finder'), QCoreApplication.translate("mainwindow_ui_tr", 'Find Video Links...'), self, statusTip=QCoreApplication.translate("mainwindow_ui_tr", 'Download video or audio from Youtube, Vimeo, etc.'),
                                                 triggered=self.showVideoFinderAddLinkWindow)
 
         self.videoFinderAddLinkAction_shortcut = QShortcut(self.persepolis_setting.value(
@@ -495,63 +495,63 @@ class MainWindow_Ui(QMainWindow):
         videoFinderMenu.addAction(self.videoFinderAddLinkAction)
 
         # stopAllAction
-        self.stopAllAction = QAction(QIcon(icons + 'stop_all'), QCoreApplication.translate("mainwindow_ui_tr", 'Stop all active downloads'),
-                                     self, statusTip='Stop all active downloads', triggered=self.stopAllDownloads)
+        self.stopAllAction = QAction(QIcon(icons + 'stop_all'), QCoreApplication.translate("mainwindow_ui_tr", 'Stop All Active Downloads'),
+                                     self, statusTip='Stop All Active Downloads', triggered=self.stopAllDownloads)
         downloadMenu.addAction(self.stopAllAction)
 
         # sort_file_name_Action
         self.sort_file_name_Action = QAction(
-            QCoreApplication.translate("mainwindow_ui_tr", 'File name'), self, triggered=self.sortByName)
+            QCoreApplication.translate("mainwindow_ui_tr", 'File Name'), self, triggered=self.sortByName)
         sortMenu.addAction(self.sort_file_name_Action)
 
         # sort_file_size_Action
         self.sort_file_size_Action = QAction(
-            QCoreApplication.translate("mainwindow_ui_tr", 'File size'), self, triggered=self.sortBySize)
+            QCoreApplication.translate("mainwindow_ui_tr", 'File Size'), self, triggered=self.sortBySize)
         sortMenu.addAction(self.sort_file_size_Action)
 
         # sort_first_try_date_Action
         self.sort_first_try_date_Action = QAction(
-            QCoreApplication.translate("mainwindow_ui_tr", 'First try date'), self, triggered=self.sortByFirstTry)
+            QCoreApplication.translate("mainwindow_ui_tr", 'First Try Date'), self, triggered=self.sortByFirstTry)
         sortMenu.addAction(self.sort_first_try_date_Action)
 
         # sort_last_try_date_Action
         self.sort_last_try_date_Action = QAction(
-            QCoreApplication.translate("mainwindow_ui_tr", 'Last try date'), self, triggered=self.sortByLastTry)
+            QCoreApplication.translate("mainwindow_ui_tr", 'Last Try Date'), self, triggered=self.sortByLastTry)
         sortMenu.addAction(self.sort_last_try_date_Action)
 
         # sort_download_status_Action
         self.sort_download_status_Action = QAction(
-            QCoreApplication.translate("mainwindow_ui_tr", 'Download status'), self, triggered=self.sortByStatus)
+            QCoreApplication.translate("mainwindow_ui_tr", 'Download Status'), self, triggered=self.sortByStatus)
         sortMenu.addAction(self.sort_download_status_Action)
 
         # trayAction
-        self.trayAction = QAction(QCoreApplication.translate("mainwindow_ui_tr", 'Show system tray icon'), self,
+        self.trayAction = QAction(QCoreApplication.translate("mainwindow_ui_tr", 'Show System Tray Icon'), self,
                                   statusTip=QCoreApplication.translate("mainwindow_ui_tr", "Show/Hide system tray icon"), triggered=self.showTray)
         self.trayAction.setCheckable(True)
         viewMenu.addAction(self.trayAction)
 
         # showMenuBarAction
         self.showMenuBarAction = QAction(
-            QCoreApplication.translate("mainwindow_ui_tr", 'Show menubar'), self, statusTip=QCoreApplication.translate("mainwindow_ui_tr", 'Show menubar'), triggered=self.showMenuBar)
+            QCoreApplication.translate("mainwindow_ui_tr", 'Show Menubar'), self, statusTip=QCoreApplication.translate("mainwindow_ui_tr", 'Show Menubar'), triggered=self.showMenuBar)
         self.showMenuBarAction.setCheckable(True)
         viewMenu.addAction(self.showMenuBarAction)
 
         # showSidePanelAction
         self.showSidePanelAction = QAction(
-            QCoreApplication.translate("mainwindow_ui_tr", 'Show side panel'), self, statusTip=QCoreApplication.translate("mainwindow_ui_tr", 'Show side panel'), triggered=self.showSidePanel)
+            QCoreApplication.translate("mainwindow_ui_tr", 'Show Side Panel'), self, statusTip=QCoreApplication.translate("mainwindow_ui_tr", 'Show Side Panel'), triggered=self.showSidePanel)
         self.showSidePanelAction.setCheckable(True)
         viewMenu.addAction(self.showSidePanelAction)
 
         # minimizeAction
-        self.minimizeAction = QAction(QIcon(icons + 'minimize'), QCoreApplication.translate("mainwindow_ui_tr", 'Minimize to system tray'), self,
-                                      statusTip=QCoreApplication.translate("mainwindow_ui_tr", "Minimize to system tray"), triggered=self.minMaxTray)
+        self.minimizeAction = QAction(QIcon(icons + 'minimize'), QCoreApplication.translate("mainwindow_ui_tr", 'Minimize to System Tray'), self,
+                                      statusTip=QCoreApplication.translate("mainwindow_ui_tr", "Minimize to System Tray"), triggered=self.minMaxTray)
 
         self.minimizeAction_shortcut = QShortcut(
             self.persepolis_setting.value('hide_window_shortcut'), self, self.minMaxTray)
         viewMenu.addAction(self.minimizeAction)
 
         # addlinkAction
-        self.addlinkAction = QAction(QIcon(icons + 'add'), QCoreApplication.translate("mainwindow_ui_tr", 'Add New Download Link'), self,
+        self.addlinkAction = QAction(QIcon(icons + 'add'), QCoreApplication.translate("mainwindow_ui_tr", 'Add New Download Link...'), self,
                                      statusTip=QCoreApplication.translate("mainwindow_ui_tr", "Add New Download Link"), triggered=self.addLinkButtonPressed)
 
         self.addlinkAction_shortcut = QShortcut(self.persepolis_setting.value(
@@ -559,8 +559,8 @@ class MainWindow_Ui(QMainWindow):
         fileMenu.addAction(self.addlinkAction)
 
         # importText
-        self.addtextfileAction = QAction(QIcon(icons + 'file'), QCoreApplication.translate("mainwindow_ui_tr", 'Import links from text file'), self,
-                                         statusTip=QCoreApplication.translate("mainwindow_ui_tr", 'Create a Text file and put links in it.line by line!'), triggered=self.importText)
+        self.addtextfileAction = QAction(QIcon(icons + 'file'), QCoreApplication.translate("mainwindow_ui_tr", 'Import Links from Text File...'), self,
+                                         statusTip=QCoreApplication.translate("mainwindow_ui_tr", 'Create a text file and put links in it, line by line!'), triggered=self.importText)
 
         self.addtextfileAction_shortcut = QShortcut(
             self.persepolis_setting.value('import_text_shortcut'), self, self.importText)
@@ -599,18 +599,18 @@ class MainWindow_Ui(QMainWindow):
 
         # openFileAction
         self.openFileAction = QAction(QIcon(
-            icons + 'file'), QCoreApplication.translate("mainwindow_ui_tr", 'Open file'), self, statusTip=QCoreApplication.translate("mainwindow_ui_tr", 'Open file'), triggered=self.openFile)
+            icons + 'file'), QCoreApplication.translate("mainwindow_ui_tr", 'Open File...'), self, statusTip=QCoreApplication.translate("mainwindow_ui_tr", 'Open File...'), triggered=self.openFile)
         fileMenu.addAction(self.openFileAction)
 
         # openDownloadFolderAction
         self.openDownloadFolderAction = QAction(QIcon(
-            icons + 'folder'), QCoreApplication.translate("mainwindow_ui_tr", 'Open download folder'), self, statusTip=QCoreApplication.translate("mainwindow_ui_tr", 'Open download folder'), triggered=self.openDownloadFolder)
+            icons + 'folder'), QCoreApplication.translate("mainwindow_ui_tr", 'Open Download Folder'), self, statusTip=QCoreApplication.translate("mainwindow_ui_tr", 'Open Download Folder'), triggered=self.openDownloadFolder)
 
         fileMenu.addAction(self.openDownloadFolderAction)
 
         # openDefaultDownloadFolderAction
         self.openDefaultDownloadFolderAction = QAction(QIcon(
-            icons + 'folder'), QCoreApplication.translate("mainwindow_ui_tr", 'Open default download folder'), self, statusTip=QCoreApplication.translate("mainwindow_ui_tr", 'Open default download folder'), triggered=self.openDefaultDownloadFolder)
+            icons + 'folder'), QCoreApplication.translate("mainwindow_ui_tr", 'Open Default Download Folder'), self, statusTip=QCoreApplication.translate("mainwindow_ui_tr", 'Open Default Download Folder'), triggered=self.openDefaultDownloadFolder)
 
         fileMenu.addAction(self.openDefaultDownloadFolderAction)
 
@@ -623,13 +623,13 @@ class MainWindow_Ui(QMainWindow):
         fileMenu.addAction(self.exitAction)
 
         # clearAction
-        self.clearAction = QAction(QIcon(icons + 'multi_remove'), QCoreApplication.translate("mainwindow_ui_tr", 'Clear download list'),
+        self.clearAction = QAction(QIcon(icons + 'multi_remove'), QCoreApplication.translate("mainwindow_ui_tr", 'Clear Download List'),
                                    self, statusTip=QCoreApplication.translate("mainwindow_ui_tr", 'Clear all items in download list'), triggered=self.clearDownloadList)
         editMenu.addAction(self.clearAction)
 
         # removeSelectedAction
-        self.removeSelectedAction = QAction(QIcon(icons + 'remove'), QCoreApplication.translate("mainwindow_ui_tr", 'Remove selected downloads from list'),
-                                            self, statusTip=QCoreApplication.translate("mainwindow_ui_tr", 'Remove selected downloads form list'), triggered=self.removeSelected)
+        self.removeSelectedAction = QAction(QIcon(icons + 'remove'), QCoreApplication.translate("mainwindow_ui_tr", 'Remove Selected Downloads from List'),
+                                            self, statusTip=QCoreApplication.translate("mainwindow_ui_tr", 'Remove Selected Downloads from List), triggered=self.removeSelected)
 
         self.removeSelectedAction_shortcut = QShortcut(
             self.persepolis_setting.value('remove_shortcut'), self, self.removeSelected)
@@ -638,8 +638,8 @@ class MainWindow_Ui(QMainWindow):
         self.removeSelectedAction.setEnabled(False)
 
         # deleteSelectedAction
-        self.deleteSelectedAction = QAction(QIcon(icons + 'trash'), QCoreApplication.translate("mainwindow_ui_tr", 'Delete selected download files'),
-                                            self, statusTip=QCoreApplication.translate("mainwindow_ui_tr", 'Delete selected download files'), triggered=self.deleteSelected)
+        self.deleteSelectedAction = QAction(QIcon(icons + 'trash'), QCoreApplication.translate("mainwindow_ui_tr", 'Delete Selected Download Files'),
+                                            self, statusTip=QCoreApplication.translate("mainwindow_ui_tr", 'Delete Selected Download Files'), triggered=self.deleteSelected)
 
         self.deleteSelectedAction_shortcut = QShortcut(
             self.persepolis_setting.value('delete_shortcut'), self, self.deleteSelected)
@@ -648,36 +648,36 @@ class MainWindow_Ui(QMainWindow):
         self.deleteSelectedAction.setEnabled(False)
 
         # moveSelectedDownloadsAction
-        self.moveSelectedDownloadsAction = QAction(QIcon(icons + 'folder'), QCoreApplication.translate("mainwindow_ui_tr", 'move selected download files to another folder'),
-                                                   self, statusTip=QCoreApplication.translate("mainwindow_ui_tr", 'move selected download files to another folder'), triggered=self.moveSelectedDownloads)
+        self.moveSelectedDownloadsAction = QAction(QIcon(icons + 'folder'), QCoreApplication.translate("mainwindow_ui_tr", 'Move Selected Download Files to Another Folder...'),
+                                                   self, statusTip=QCoreApplication.translate("mainwindow_ui_tr", 'Move Selected Download Files to Another Folder'), triggered=self.moveSelectedDownloads)
 
         editMenu.addAction(self.moveSelectedDownloadsAction)
         self.moveSelectedDownloadsAction.setEnabled(False)
 
         # createQueueAction
-        self.createQueueAction = QAction(QIcon(icons + 'add_queue'), QCoreApplication.translate("mainwindow_ui_tr", 'Create new queue'),
+        self.createQueueAction = QAction(QIcon(icons + 'add_queue'), QCoreApplication.translate("mainwindow_ui_tr", 'Create New Queue...'),
                                          self, statusTip=QCoreApplication.translate("mainwindow_ui_tr", 'Create new download queue'), triggered=self.createQueue)
         queueMenu.addAction(self.createQueueAction)
 
         # removeQueueAction
-        self.removeQueueAction = QAction(QIcon(icons + 'remove_queue'), QCoreApplication.translate("mainwindow_ui_tr", 'Remove this queue'),
+        self.removeQueueAction = QAction(QIcon(icons + 'remove_queue'), QCoreApplication.translate("mainwindow_ui_tr", 'Remove Queue'),
                                          self, statusTip=QCoreApplication.translate("mainwindow_ui_tr", 'Remove this queue'), triggered=self.removeQueue)
         queueMenu.addAction(self.removeQueueAction)
 
         # startQueueAction
         self.startQueueAction = QAction(QIcon(
-            icons + 'start_queue'), QCoreApplication.translate("mainwindow_ui_tr", 'Start this queue'), self, statusTip=QCoreApplication.translate("mainwindow_ui_tr", 'Start this queue'), triggered=self.startQueue)
+            icons + 'start_queue'), QCoreApplication.translate("mainwindow_ui_tr", 'Start this queue'), self, statusTip=QCoreApplication.translate("mainwindow_ui_tr", 'Start Queue'), triggered=self.startQueue)
 
         queueMenu.addAction(self.startQueueAction)
 
         # stopQueueAction
         self.stopQueueAction = QAction(QIcon(
-            icons + 'stop_queue'), QCoreApplication.translate("mainwindow_ui_tr", 'Stop this queue'), self, statusTip=QCoreApplication.translate("mainwindow_ui_tr", 'Stop this queue'), triggered=self.stopQueue)
+            icons + 'stop_queue'), QCoreApplication.translate("mainwindow_ui_tr", 'Stop this queue'), self, statusTip=QCoreApplication.translate("mainwindow_ui_tr", 'Stop Queue'), triggered=self.stopQueue)
 
         queueMenu.addAction(self.stopQueueAction)
 
         # moveUpSelectedAction
-        self.moveUpSelectedAction = QAction(QIcon(icons + 'multi_up'), QCoreApplication.translate("mainwindow_ui_tr", 'Move up selected items'), self,
+        self.moveUpSelectedAction = QAction(QIcon(icons + 'multi_up'), QCoreApplication.translate("mainwindow_ui_tr", 'Move Selected Items Up'), self,
                                             statusTip=QCoreApplication.translate("mainwindow_ui_tr", 'Move currently selected items up by one row'), triggered=self.moveUpSelected)
 
         self.moveUpSelectedAction_shortcut = QShortcut(self.persepolis_setting.value(
@@ -686,7 +686,7 @@ class MainWindow_Ui(QMainWindow):
         queueMenu.addAction(self.moveUpSelectedAction)
 
         # moveDownSelectedAction
-        self.moveDownSelectedAction = QAction(QIcon(icons + 'multi_down'), QCoreApplication.translate("mainwindow_ui_tr", 'Move down selected items'),
+        self.moveDownSelectedAction = QAction(QIcon(icons + 'multi_down'), QCoreApplication.translate("mainwindow_ui_tr", 'Move Selected Items Down'),
                                               self, statusTip=QCoreApplication.translate("mainwindow_ui_tr", 'Move currently selected items down by one row'), triggered=self.moveDownSelected)
         self.moveDownSelectedAction_shortcut = QShortcut(self.persepolis_setting.value(
             'move_down_selection_shortcut'), self, self.moveDownSelected)
@@ -704,17 +704,17 @@ class MainWindow_Ui(QMainWindow):
         helpMenu.addAction(self.aboutAction)
 
         # issueAction
-        self.issueAction = QAction(QIcon(icons + 'about'), QCoreApplication.translate("mainwindow_ui_tr", 'Report an issue'),
+        self.issueAction = QAction(QIcon(icons + 'about'), QCoreApplication.translate("mainwindow_ui_tr", 'Report an Issue'),
                                    self, statusTip=QCoreApplication.translate("mainwindow_ui_tr", 'Report an issue'), triggered=self.reportIssue)
         helpMenu.addAction(self.issueAction)
 
         # updateAction
-        self.updateAction = QAction(QIcon(icons + 'about'), QCoreApplication.translate("mainwindow_ui_tr", 'Check for newer version'),
+        self.updateAction = QAction(QIcon(icons + 'about'), QCoreApplication.translate("mainwindow_ui_tr", 'Check for Newer Version'),
                                     self, statusTip=QCoreApplication.translate("mainwindow_ui_tr", 'Check for newer release'), triggered=self.newUpdate)
         helpMenu.addAction(self.updateAction)
 
         # logAction
-        self.logAction = QAction(QIcon(icons + 'about'), QCoreApplication.translate("mainwindow_ui_tr", 'Show log file'),
+        self.logAction = QAction(QIcon(icons + 'about'), QCoreApplication.translate("mainwindow_ui_tr", 'Show Log File'),
                                  self, statusTip=QCoreApplication.translate("mainwindow_ui_tr", 'Help'), triggered=self.showLog)
         helpMenu.addAction(self.logAction)
 
@@ -731,7 +731,7 @@ class MainWindow_Ui(QMainWindow):
 
 
 # labels
-        self.queue_panel_show_button.setText(QCoreApplication.translate("mainwindow_ui_tr", "Hide options"))
+        self.queue_panel_show_button.setText(QCoreApplication.translate("mainwindow_ui_tr", "Hide Options"))
         self.start_checkBox.setText(QCoreApplication.translate("mainwindow_ui_tr", "Start Time"))
 
         self.end_checkBox.setText(QCoreApplication.translate("mainwindow_ui_tr", "End Time"))
@@ -747,17 +747,17 @@ class MainWindow_Ui(QMainWindow):
         self.after_checkBox.setText(QCoreApplication.translate("mainwindow_ui_tr", "After download"))
         self.after_comboBox.setItemText(0, QCoreApplication.translate("mainwindow_ui_tr", "Shut Down"))
 
-        self.keep_awake_checkBox.setText(QCoreApplication.translate("mainwindow_ui_tr", "Keep system awake!"))
+        self.keep_awake_checkBox.setText(QCoreApplication.translate("mainwindow_ui_tr", "Keep System Awake!"))
         self.keep_awake_checkBox.setToolTip(
-            QCoreApplication.translate("mainwindow_ui_tr", "<html><head/><body><p>This option is preventing system from going to sleep.\
-            This is necessary if your power manager is suspending system automatically. </p></body></html>"))
+            QCoreApplication.translate("mainwindow_ui_tr", "<html><head/><body><p>This option will prevent the system from going to sleep.\
+            It is necessary if your power manager is suspending the system automatically. </p></body></html>"))
 
         self.after_pushButton.setText(QCoreApplication.translate("mainwindow_ui_tr", "Apply"))
 
-        self.muxing_pushButton.setText(QCoreApplication.translate("mainwindow_ui_tr", "start muxing"))
+        self.muxing_pushButton.setText(QCoreApplication.translate("mainwindow_ui_tr", "Start Mixing"))
 
-        self.video_label.setText(QCoreApplication.translate("mainwindow_ui_tr", "<b>Video file status: </b>"))
-        self.audio_label.setText(QCoreApplication.translate("mainwindow_ui_tr", "<b>Audio file status: </b>"))
+        self.video_label.setText(QCoreApplication.translate("mainwindow_ui_tr", "<b>Video File Status: </b>"))
+        self.audio_label.setText(QCoreApplication.translate("mainwindow_ui_tr", "<b>Audio File Status: </b>"))
 
         self.video_finder_status_label.setText(QCoreApplication.translate("mainwindow_ui_tr", "<b>Status: </b>"))
-        self.muxing_status_label.setText(QCoreApplication.translate("mainwindow_ui_tr", "<b>Muxing status: </b>"))
+        self.muxing_status_label.setText(QCoreApplication.translate("mainwindow_ui_tr", "<b>Mixing status: </b>"))

--- a/persepolis/gui/progress_ui.py
+++ b/persepolis/gui/progress_ui.py
@@ -203,7 +203,7 @@ class ProgressWindow_Ui(QWidget):
         self.downloaded_label.setText(QCoreApplication.translate("progress_ui_tr", "Downloaded:"))
         self.rate_label.setText(QCoreApplication.translate("progress_ui_tr", "Transfer rate: "))
         self.time_label.setText(QCoreApplication.translate("progress_ui_tr", "Estimated time left:"))
-        self.connections_label.setText(QCoreApplication.translate("progress_ui_tr", "Connections: "))
+        self.connections_label.setText(QCoreApplication.translate("progress_ui_tr", "Number of connections: "))
         self.progress_tabWidget.setTabText(self.progress_tabWidget.indexOf(
             self.information_tab),  QCoreApplication.translate("progress_ui_tr", "Download Information"))
         self.limit_checkBox.setText(QCoreApplication.translate("progress_ui_tr", "Limit speed"))

--- a/persepolis/gui/progress_ui.py
+++ b/persepolis/gui/progress_ui.py
@@ -198,15 +198,15 @@ class ProgressWindow_Ui(QWidget):
 
         self.progress_tabWidget.setCurrentIndex(0)
 # labels
-        self.link_label.setText(QCoreApplication.translate("progress_ui_tr", "Link:"))
+        self.link_label.setText(QCoreApplication.translate("progress_ui_tr", "Link: "))
         self.status_label.setText(QCoreApplication.translate("progress_ui_tr", "Status: "))
         self.downloaded_label.setText(QCoreApplication.translate("progress_ui_tr", "Downloaded:"))
         self.rate_label.setText(QCoreApplication.translate("progress_ui_tr", "Transfer rate: "))
         self.time_label.setText(QCoreApplication.translate("progress_ui_tr", "Estimated time left:"))
-        self.connections_label.setText(QCoreApplication.translate("progress_ui_tr", "Number of connections: "))
+        self.connections_label.setText(QCoreApplication.translate("progress_ui_tr", "Connections: "))
         self.progress_tabWidget.setTabText(self.progress_tabWidget.indexOf(
             self.information_tab),  QCoreApplication.translate("progress_ui_tr", "Download Information"))
-        self.limit_checkBox.setText(QCoreApplication.translate("progress_ui_tr", "Limit Speed"))
+        self.limit_checkBox.setText(QCoreApplication.translate("progress_ui_tr", "Limit speed"))
         self.after_checkBox.setText(QCoreApplication.translate("progress_ui_tr", "After download"))
         self.limit_comboBox.setItemText(0, "KiB/s")
         self.limit_comboBox.setItemText(1, "MiB/s")

--- a/persepolis/gui/setting_ui.py
+++ b/persepolis/gui/setting_ui.py
@@ -319,7 +319,7 @@ class Setting_Ui(QWidget):
 
         style_tab_verticalLayout.addLayout(language_horizontalLayout)
         language_horizontalLayout = QHBoxLayout()
-        self.lang_label.setText(QCoreApplication.translate("setting_ui_tr", "Language:"))
+        self.lang_label.setText(QCoreApplication.translate("setting_ui_tr", "Language: "))
 
         # color scheme
         self.color_label = QLabel(self.style_tab)
@@ -500,14 +500,14 @@ class Setting_Ui(QWidget):
 
         # Actions
         actions_list = [QCoreApplication.translate('setting_ui_tr', 'Quit'),
-                        QCoreApplication.translate('setting_ui_tr', 'Minimize main window to the tray icon'),
-                        QCoreApplication.translate('setting_ui_tr', 'Remove download items'),
-                        QCoreApplication.translate('setting_ui_tr', 'Delete download items'),
-                        QCoreApplication.translate('setting_ui_tr', 'Move up selected items'),
-                        QCoreApplication.translate('setting_ui_tr', 'Move down selected items'),
-                        QCoreApplication.translate('setting_ui_tr', 'Add new download link'),
-                        QCoreApplication.translate('setting_ui_tr', 'Add new video link'),
-                        QCoreApplication.translate('setting_ui_tr', 'Import links from text file')]
+                        QCoreApplication.translate('setting_ui_tr', 'Minimize to System Tray'),
+                        QCoreApplication.translate('setting_ui_tr', 'Remove Download Items'),
+                        QCoreApplication.translate('setting_ui_tr', 'Delete Download Items'),
+                        QCoreApplication.translate('setting_ui_tr', 'Move Selected Items Up'),
+                        QCoreApplication.translate('setting_ui_tr', 'Move Selected Items Down'),
+                        QCoreApplication.translate('setting_ui_tr', 'Add New Download Link'),
+                        QCoreApplication.translate('setting_ui_tr', 'Add New Video Link'),
+                        QCoreApplication.translate('setting_ui_tr', 'Import Links from Text File')]
 
         # add actions to the shortcut_table
         j = 0
@@ -556,7 +556,7 @@ class Setting_Ui(QWidget):
 
         self.wait_label.setToolTip(
             QCoreApplication.translate("setting_ui_tr", "<html><head/><body><p>Set the seconds to wait between retries. Download manager will  retry  downloads  when  the  HTTP  server  returns  a  503 response.</p></body></html>"))
-        self.wait_label.setText(QCoreApplication.translate("setting_ui_tr", "Wait between retries (seconds): "))
+        self.wait_label.setText(QCoreApplication.translate("setting_ui_tr", "Wait period between retries (seconds): "))
         self.wait_spinBox.setToolTip(
             QCoreApplication.translate("setting_ui_tr", "<html><head/><body><p>Set the seconds to wait between retries. Download manager will  retry  downloads  when  the  HTTP  server  returns  a  503 response.</p></body></html>"))
 
@@ -577,12 +577,12 @@ class Setting_Ui(QWidget):
             QCoreApplication.translate("setting_ui_tr", "<html><head/><body><p> Specify a port number for JSON-RPC/XML-RPC server to listen to. Possible Values: 1024 - 65535 Default: 6801 </p></body></html>"))
 
         self.wait_queue_label.setText(QCoreApplication.translate(
-            "setting_ui_tr", 'Wait between every downloads in queue:'))
+            "setting_ui_tr", 'Wait period between each download in queue:'))
 
         self.aria2_path_checkBox.setText(QCoreApplication.translate("setting_ui_tr", 'Change Aria2 default path'))
         self.aria2_path_pushButton.setText(QCoreApplication.translate("setting_ui_tr", 'Change'))
         aria2_path_tooltip = QCoreApplication.translate(
-            "setting_ui_tr", "<html><head/><body><p>Attention: Wrong path may have caused problem! Do it carefully or don't change default setting!</p></body></html>")
+            "setting_ui_tr", "<html><head/><body><p>Attention: Wrong path may cause problems! Do it carefully or don't change default setting!</p></body></html>")
         self.aria2_path_checkBox.setToolTip(aria2_path_tooltip)
         self.aria2_path_lineEdit.setToolTip(aria2_path_tooltip)
         self.aria2_path_pushButton.setToolTip(aria2_path_tooltip)
@@ -590,20 +590,20 @@ class Setting_Ui(QWidget):
         self.setting_tabWidget.setTabText(self.setting_tabWidget.indexOf(
             self.download_options_tab),  QCoreApplication.translate("setting_ui_tr", "Download Options"))
 
-        self.download_folder_label.setText(QCoreApplication.translate("setting_ui_tr", "Download Folder: "))
+        self.download_folder_label.setText(QCoreApplication.translate("setting_ui_tr", "Download folder: "))
         self.download_folder_pushButton.setText(QCoreApplication.translate("setting_ui_tr", "Change"))
 
-        self.temp_download_label.setText(QCoreApplication.translate("setting_ui_tr", "Temporary Download Folder: "))
+        self.temp_download_label.setText(QCoreApplication.translate("setting_ui_tr", "Temporary download folder: "))
         self.temp_download_pushButton.setText(QCoreApplication.translate("setting_ui_tr", "Change"))
 
         self.subfolder_checkBox.setText(QCoreApplication.translate(
-            "setting_ui_tr", "Create subfolders for Music,Videos,... in default download folder"))
+            "setting_ui_tr", "Create subfolders for Music,Videos, ... in default download folder"))
 
         self.setting_tabWidget.setTabText(
-            self.setting_tabWidget.indexOf(self.save_as_tab),  QCoreApplication.translate("setting_ui_tr", "Save as"))
+            self.setting_tabWidget.indexOf(self.save_as_tab),  QCoreApplication.translate("setting_ui_tr", "Save As"))
 
         self.enable_notifications_checkBox.setText(
-            QCoreApplication.translate("setting_ui_tr", "Enable notification sounds"))
+            QCoreApplication.translate("setting_ui_tr", "Enable Notification Sounds"))
 
         self.volume_label.setText(QCoreApplication.translate("setting_ui_tr", "Volume: "))
 
@@ -614,7 +614,7 @@ class Setting_Ui(QWidget):
         self.color_label.setText(QCoreApplication.translate("setting_ui_tr", "Color scheme: "))
         self.icon_label.setText(QCoreApplication.translate("setting_ui_tr", "Icons: "))
 
-        self.icons_size_label.setText(QCoreApplication.translate("setting_ui_tr", "Toolbar's icons size: "))
+        self.icons_size_label.setText(QCoreApplication.translate("setting_ui_tr", "Toolbar icons size: "))
 
         self.notification_label.setText(QCoreApplication.translate("setting_ui_tr", "Notification type: "))
 
@@ -627,25 +627,25 @@ class Setting_Ui(QWidget):
             QCoreApplication.translate("setting_ui_tr", "<html><head/><body><p>This feature may not work in your operating system.</p></body></html>"))
 
         self.start_persepolis_if_browser_executed_checkBox.setText(
-            QCoreApplication.translate('setting_ui_tr', 'Start Persepolis in system tray, if browser is executed.'))
+            QCoreApplication.translate('setting_ui_tr', 'If executed by browser, start Persepolis in system tray'))
 
         self.enable_system_tray_checkBox.setText(
-            QCoreApplication.translate("setting_ui_tr", "Enable system tray icon."))
+            QCoreApplication.translate("setting_ui_tr", "Enable system tray icon"))
 
         self.after_download_checkBox.setText(
-            QCoreApplication.translate("setting_ui_tr", "Show download complete dialog when download has finished."))
+            QCoreApplication.translate("setting_ui_tr", "Show download complete dialog when download is finished"))
 
-        self.show_menubar_checkbox.setText(QCoreApplication.translate("setting_ui_tr", "Show menubar."))
-        self.show_sidepanel_checkbox.setText(QCoreApplication.translate("setting_ui_tr", "Show side panel."))
+        self.show_menubar_checkbox.setText(QCoreApplication.translate("setting_ui_tr", "Show menubar"))
+        self.show_sidepanel_checkbox.setText(QCoreApplication.translate("setting_ui_tr", "Show side panel"))
         self.show_progress_window_checkbox.setText(
-            QCoreApplication.translate("setting_ui_tr", "Show download's progress window"))
+            QCoreApplication.translate("setting_ui_tr", "Show download progress window"))
 
         self.startup_checkbox.setText(QCoreApplication.translate("setting_ui_tr", "Run Persepolis at startup"))
 
         self.keep_awake_checkBox.setText(QCoreApplication.translate("setting_ui_tr", "Keep system awake!"))
         self.keep_awake_checkBox.setToolTip(
-            QCoreApplication.translate("setting_ui_tr", "<html><head/><body><p>This option is preventing system from going to sleep.\
-            This is necessary if your power manager is suspending system automatically. </p></body></html>"))
+            QCoreApplication.translate("setting_ui_tr", "<html><head/><body><p>This option will prevent the system from going to sleep.\
+            It is necessary if your power manager is suspending the system automatically. </p></body></html>"))
 
         self.wait_queue_time.setToolTip(
             QCoreApplication.translate("setting_ui_tr", "<html><head/><body><p>Format HH:MM</p></body></html>"))
@@ -654,21 +654,21 @@ class Setting_Ui(QWidget):
             self.setting_tabWidget.indexOf(self.style_tab),  QCoreApplication.translate("setting_ui_tr", "Preferences"))
 
 # columns_tab
-        self.show_column_label.setText(QCoreApplication.translate("setting_ui_tr", 'Show this columns:'))
+        self.show_column_label.setText(QCoreApplication.translate("setting_ui_tr", 'Show these columns:'))
         self.column0_checkBox.setText(QCoreApplication.translate("setting_ui_tr", 'File Name'))
         self.column1_checkBox.setText(QCoreApplication.translate("setting_ui_tr", 'Status'))
         self.column2_checkBox.setText(QCoreApplication.translate("setting_ui_tr", 'Size'))
         self.column3_checkBox.setText(QCoreApplication.translate("setting_ui_tr", 'Downloaded'))
         self.column4_checkBox.setText(QCoreApplication.translate("setting_ui_tr", 'Percentage'))
         self.column5_checkBox.setText(QCoreApplication.translate("setting_ui_tr", 'Connections'))
-        self.column6_checkBox.setText(QCoreApplication.translate("setting_ui_tr", 'Transfer rate'))
-        self.column7_checkBox.setText(QCoreApplication.translate("setting_ui_tr", 'Estimated time left'))
-        self.column10_checkBox.setText(QCoreApplication.translate("setting_ui_tr", 'First try date'))
-        self.column11_checkBox.setText(QCoreApplication.translate("setting_ui_tr", 'Last try date'))
+        self.column6_checkBox.setText(QCoreApplication.translate("setting_ui_tr", 'Transfer Rate'))
+        self.column7_checkBox.setText(QCoreApplication.translate("setting_ui_tr", 'Estimated Time Left'))
+        self.column10_checkBox.setText(QCoreApplication.translate("setting_ui_tr", 'First Try Date'))
+        self.column11_checkBox.setText(QCoreApplication.translate("setting_ui_tr", 'Last Try Date'))
         self.column12_checkBox.setText(QCoreApplication.translate("setting_ui_tr", 'Category'))
 
         self.setting_tabWidget.setTabText(
-            self.setting_tabWidget.indexOf(self.columns_tab), QCoreApplication.translate("setting_ui_tr", "Columns customization"))
+            self.setting_tabWidget.indexOf(self.columns_tab), QCoreApplication.translate("setting_ui_tr", "Columns Customization"))
 
 # Video Finder options tab
         self.setting_tabWidget.setTabText(self.setting_tabWidget.indexOf(

--- a/persepolis/gui/setting_ui.py
+++ b/persepolis/gui/setting_ui.py
@@ -627,7 +627,7 @@ class Setting_Ui(QWidget):
             QCoreApplication.translate("setting_ui_tr", "<html><head/><body><p>This feature may not work in your operating system.</p></body></html>"))
 
         self.start_persepolis_if_browser_executed_checkBox.setText(
-            QCoreApplication.translate('setting_ui_tr', 'If executed by browser, start Persepolis in system tray'))
+            QCoreApplication.translate('setting_ui_tr', 'If browser is opened, start Persepolis in system tray'))
 
         self.enable_system_tray_checkBox.setText(
             QCoreApplication.translate("setting_ui_tr", "Enable system tray icon"))

--- a/persepolis/gui/text_queue_ui.py
+++ b/persepolis/gui/text_queue_ui.py
@@ -141,7 +141,7 @@ class TextQueue_Ui(QWidget):
         proxy_verticalLayout.addWidget(self.proxy_frame)
         options_tab_verticalLayout.addLayout(proxy_verticalLayout)
 
-        # download UserName & Password
+        # download Username & Password
         download_horizontalLayout = QHBoxLayout()
         download_horizontalLayout.setContentsMargins(-1, 10, -1, -1)
 
@@ -265,7 +265,7 @@ class TextQueue_Ui(QWidget):
         self.queue_tabWidget.setTabText(
             self.queue_tabWidget.indexOf(self.links_tab), QCoreApplication.translate("text_ui_tr", 'Links'))
         self.queue_tabWidget.setTabText(
-            self.queue_tabWidget.indexOf(self.options_tab), QCoreApplication.translate("text_ui_tr", 'Download options'))
+            self.queue_tabWidget.indexOf(self.options_tab), QCoreApplication.translate("text_ui_tr", 'Download Options'))
 
         self.select_all_pushButton.setText(QCoreApplication.translate("text_ui_tr", 'Select All'))
         self.deselect_all_pushButton.setText(QCoreApplication.translate("text_ui_tr", 'Deselect All'))
@@ -273,21 +273,21 @@ class TextQueue_Ui(QWidget):
         self.add_queue_label.setText(QCoreApplication.translate("text_ui_tr", 'Add to queue: '))
 
         self.proxy_checkBox.setText(QCoreApplication.translate("text_ui_tr", 'Proxy'))
-        self.proxy_pass_label.setText(QCoreApplication.translate("text_ui_tr", "Proxy PassWord: "))
+        self.proxy_pass_label.setText(QCoreApplication.translate("text_ui_tr", "Proxy password: "))
         self.ip_label.setText(QCoreApplication.translate("text_ui_tr", "IP:"))
-        self.proxy_user_label.setText(QCoreApplication.translate("text_ui_tr", "Proxy UserName: "))
+        self.proxy_user_label.setText(QCoreApplication.translate("text_ui_tr", "Proxy username: "))
         self.port_label.setText(QCoreApplication.translate("text_ui_tr", "Port:"))
 
-        self.download_checkBox.setText(QCoreApplication.translate("text_ui_tr", "Download UserName and PassWord"))
-        self.download_user_label.setText(QCoreApplication.translate("text_ui_tr", "Download UserName: "))
-        self.download_pass_label.setText(QCoreApplication.translate("text_ui_tr", "Download PassWord: "))
+        self.download_checkBox.setText(QCoreApplication.translate("text_ui_tr", "Download username and password"))
+        self.download_user_label.setText(QCoreApplication.translate("text_ui_tr", "Download username: "))
+        self.download_pass_label.setText(QCoreApplication.translate("text_ui_tr", "Download password: "))
 
         self.folder_pushButton.setText(QCoreApplication.translate("text_ui_tr", "Change Download Folder"))
-        self.folder_label.setText(QCoreApplication.translate("text_ui_tr", "Download Folder: "))
+        self.folder_label.setText(QCoreApplication.translate("text_ui_tr", "Download folder: "))
 
-        self.limit_checkBox.setText(QCoreApplication.translate("text_ui_tr", "Limit Speed"))
+        self.limit_checkBox.setText(QCoreApplication.translate("text_ui_tr", "Limit speed"))
 
-        self.connections_label.setText(QCoreApplication.translate("text_ui_tr", "Number Of Connections:"))
+        self.connections_label.setText(QCoreApplication.translate("text_ui_tr", "Number of connections:"))
 
         self.ok_pushButton.setText(QCoreApplication.translate("text_ui_tr", 'OK'))
         self.cancel_pushButton.setText(QCoreApplication.translate("text_ui_tr", 'Cancel'))

--- a/persepolis/gui/video_finder_progress_ui.py
+++ b/persepolis/gui/video_finder_progress_ui.py
@@ -51,7 +51,7 @@ class VideoFinderProgressWindow_Ui(ProgressWindow_Ui):
         self.audio_status_label.setText(QCoreApplication.translate(
             "video_finder_progress_ui_tr", "<b>Audio file status: </b>"))
         self.muxing_status_label.setText(QCoreApplication.translate(
-            "video_finder_progress_ui_tr", "<b>Muxing status: </b>"))
+            "video_finder_progress_ui_tr", "<b>Mixing status: </b>"))
 
         self.progress_tabWidget.setTabText(self.progress_tabWidget.indexOf(
             self.status_tab),  QCoreApplication.translate("setting_ui_tr", "Status"))


### PR DESCRIPTION
Fixed typos and capitalization :heavy_check_mark: 

Used the GNOME interface writing guidelines found here: https://developer.gnome.org/hig/stable/writing-style.html.en

Changes:

- Added "..." after menu items that require further interaction
- Change "UserName" and "PassWord" to "Username" and "Password" respectively
- Apply "title case" to title style headings and "sentence case" to conversational headings
	E.g.,
		"Number Of Connections" becomes "Number of Connections" when not before checkbox
		"Download options" becomes "Download Options"

- Use "title case" for buttons, menus, etc
- Use "sentence case" for labels which lead to user input such as text fields and checkboxes
- Change ", etc..." to ", etc.". Only one of ", etc." and "..." should be used because they are functionally identical
- Change "Muxing" to "Mixing"
- Remove periods (.) after checkbox labels in preferences UI

+ Other various typos ^^

Thanks for the great work! :slightly_smiling_face: 