### PR TITLE
docs: fix simple typo, highliting -> highlighting

### DIFF
--- a/persepolis/scripts/mainwindow.py
+++ b/persepolis/scripts/mainwindow.py
@@ -4244,7 +4244,7 @@ class MainWindow(MainWindow_Ui):
                 if category_tree_item_text == queue_name:
                     category_index = i
                     break
-            # highliting
+            # highlighting
             category_tree_model_index = self.category_tree_model.index(
                 category_index, 0)
             self.category_tree.setCurrentIndex(category_tree_model_index)


### PR DESCRIPTION
There is a small typo in persepolis/scripts/mainwindow.py.

Should read `highlighting` rather than `highliting`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md