### PR TITLE
Fix setup test failing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -143,7 +143,7 @@ if not_installed != '':
 
 if sys.argv[1] == "test":
     print('We have not unit test :)')
-    sys.exit('0')
+    sys.exit(0)
 
 DESCRIPTION = 'Persepolis Download Manager'
 


### PR DESCRIPTION
`sys.exit('0')` prints 0 and exits with code 1.
This broke the build in nixpkgs when we tried to
enable tests to make the packaging code more idiomatic. See https://github.com/NixOS/nixpkgs/pull/292837