### PR TITLE
Fix [buid-system] section in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["mesonpy"]
-build-backend = "meson-python"
+requires = ["meson-python"]
+build-backend = "mesonpy"
 
 [tool.setuptools]
 py-modules = ["persepolis"]


### PR DESCRIPTION
It seems that this is the correct way to require meson. Although, I still get errors from meson-python about installation path's when I want to use the standard method of building packages, but it's a step forward :P