### PR TITLE
Edited desktop file comment attributes

### DIFF
--- a/xdg/com.github.persepolisdm.persepolis.desktop.in
+++ b/xdg/com.github.persepolisdm.persepolis.desktop.in
@@ -1,9 +1,10 @@
 [Desktop Entry]
 Actions=Open;Tray;
 Categories=Qt;Network;
-Comment[en_US]=Download Manager
-Comment=Download Manager
-Comment[ko]=다운로드 관리자
+Comment[en_US]=A download manager written in Python
+Comment=A download manager written in Python
+Comment[fa]=نرم افزار مدیریت بارگیری نوشته شده با پایتون
+Comment[ko]=Python으로 작성된 다운로드 관리자
 Exec=persepolis
 GenericName[en_US]=Download Manager
 GenericName=Download Manager


### PR DESCRIPTION
If you run `desktop-file-validate` on current desktop file, you will see these warnings:
```
$ desktop-file-validate com.github.persepolisdm.persepolis.desktop
com.github.persepolisdm.persepolis.desktop: warning: value "Download Manager" for key "Comment[en_US]" in group "Desktop Entry" looks the same as that of key "GenericName[en_US]"
com.github.persepolisdm.persepolis.desktop: warning: value "Download Manager" for key "Comment" in group "Desktop Entry" looks the same as that of key "GenericName"
com.github.persepolisdm.persepolis.desktop: warning: value "다운로드 관리자" for key "Comment[ko]" in group "Desktop Entry" looks the same as that of key "GenericName[ko]"
```
I corrected comment entries so these warnings are gone and desktop file shows better description.