### PR TITLE
Fix: new_download_path not initialized when download path is not the default

### DIFF
--- a/persepolis/scripts/persepolis_lib_prime.py
+++ b/persepolis/scripts/persepolis_lib_prime.py
@@ -827,6 +827,9 @@ class Download():
                 # return new download_path according to file extension.
                 new_download_path = self.findDownloadPath(
                     self.file_name, self.download_path, self.main_window.persepolis_setting.value('settings/subfolder'))
+            else:
+                # keep user specified download_path
+                new_download_path = self.file_path
 
             # if file is related to VideoFinder thread, don't move it from temp folder...
             video_finder_dictionary = self.main_window.persepolis_db.searchGidInVideoFinderTable(self.gid)


### PR DESCRIPTION
If you change path before downloading, when download is completed, an exception is thrown in background and "Open File" and "Open Download Folder" buttons won't work.

Fixed it by initializing `new_download_path` with the user specified path.