### PR TITLE
GUI Support for Enabling/Disabling Native Messaging Support Per Browser

### DIFF
--- a/persepolis/gui/setting_ui.py
+++ b/persepolis/gui/setting_ui.py
@@ -481,6 +481,56 @@ class Setting_Ui(QWidget):
 
         self.setting_tabWidget.addTab(self.shortcut_tab, QCoreApplication.translate("setting_ui_tr", "Shortcuts"))
 
+        # browser_integration_tab
+        self.browser_integration_tab = QWidget()
+        browser_integration_layout = QVBoxLayout(self.browser_integration_tab)
+
+        # Checkboxes for known browsers
+        self.browser_checkboxes = {
+            "firefox": QCheckBox("Firefox"),
+            "brave": QCheckBox("Brave"),
+            "librewolf": QCheckBox("LibreWolf"),
+            "chrome": QCheckBox("Chrome"),
+            "chromium": QCheckBox("Chromium"),
+            "opera": QCheckBox("Opera"),
+            "vivaldi": QCheckBox("Vivaldi")  
+        }
+
+        for checkbox in self.browser_checkboxes.values():
+            browser_integration_layout.addWidget(checkbox)
+
+        # Optional: custom path
+        self.custom_path_label = QLabel("Custom manifest path (optional):")
+        self.custom_path_input = QLineEdit()
+        browser_integration_layout.addWidget(self.custom_path_label)
+        browser_integration_layout.addWidget(self.custom_path_input)
+
+        browser_integration_layout.addStretch(1)
+
+        self.setting_tabWidget.addTab(
+            self.browser_integration_tab,
+            QCoreApplication.translate("setting_ui_tr", "Browser Integration")
+        )
+
+        # Load checkbox states from settings
+        self.persepolis_setting.beginGroup('settings/native_messaging')
+
+        default_enabled_browsers = ['chrome', 'chromium', 'opera', 'vivaldi', 'firefox', 'brave', 'librewolf']
+
+        for browser, checkbox in self.browser_checkboxes.items():
+            value = self.persepolis_setting.value(browser)
+            if value is None:
+                checkbox.setChecked(browser in default_enabled_browsers)
+            else:
+                checkbox.setChecked(value == 'true')
+
+        custom_path = self.persepolis_setting.value("custom_manifest_path", "")
+        self.custom_path_input.setText(custom_path)
+
+        self.persepolis_setting.endGroup()
+
+
+
         # Actions
         actions_list = [QCoreApplication.translate('setting_ui_tr', 'Quit'),
                         QCoreApplication.translate('setting_ui_tr', 'Minimize to System Tray'),

--- a/persepolis/scripts/browser_integration.py
+++ b/persepolis/scripts/browser_integration.py
@@ -13,258 +13,143 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+
 from persepolis.scripts.useful_tools import determineConfigFolder, getExecPath, findExternalAppPath
 from persepolis.scripts import osCommands
 from persepolis.constants import OS, BROWSER
-import subprocess
-import platform
 import os
+import platform
+import subprocess
+import json
+import sys
+if sys.platform == "win32":
+    import winreg
 
 os_type = platform.system()
-
 home_address = str(os.path.expanduser("~"))
 
 # download manager config folder .
 config_folder = determineConfigFolder()
 
-
+# Mapping for registry keys per browser
+windows_registry_paths = {
+    BROWSER.CHROME: r"SOFTWARE\Google\Chrome\NativeMessagingHosts\com.persepolis.chrome",
+    BROWSER.CHROMIUM: r"SOFTWARE\Chromium\NativeMessagingHosts\com.persepolis.chromium",
+    BROWSER.BRAVE: r"SOFTWARE\BraveSoftware\Brave-Browser\NativeMessagingHosts\com.persepolis.brave",
+    BROWSER.VIVALDI: r"SOFTWARE\Vivaldi\NativeMessagingHosts\com.persepolis.vivaldi",
+    BROWSER.OPERA: r"SOFTWARE\Opera Software\Opera Stable\NativeMessagingHosts\com.persepolis.opera",
+    BROWSER.FIREFOX: r"SOFTWARE\Mozilla\NativeMessagingHosts\com.persepolis.firefox",
+    "librewolf": r"SOFTWARE\Mozilla\NativeMessagingHosts\com.persepolis.librewolf"
+}
 def browserIntegration(browser, custom_path=None):
-    # get execution information.
     exec_dictionary = getExecPath()
     exec_path = exec_dictionary['modified_exec_file_path']
-
     logg_message = ["", "INITIALIZATION"]
 
-    # for GNU/Linux
-    if os_type == OS.LINUX:
-        # intermediate shell script path
+    if os_type == OS.LINUX or os_type in OS.BSD_FAMILY or os_type == OS.OSX:
         intermediary = os.path.join(config_folder, 'persepolis_run_shell')
-
-        # Native Messaging Hosts folder path for every browser
-        if custom_path:
-            native_message_folder = os.path.expanduser(custom_path)
-        elif browser == BROWSER.CHROMIUM:
-            native_message_folder = home_address + '/.config/chromium/NativeMessagingHosts'
-
-        elif browser == BROWSER.CHROME:
-            native_message_folder = home_address + \
-                '/.config/google-chrome/NativeMessagingHosts'
-
-        elif browser == BROWSER.FIREFOX:
-            native_message_folder = home_address + \
-                '/.mozilla/native-messaging-hosts'
-
-        elif browser == BROWSER.VIVALDI:
-            native_message_folder = home_address + \
-                '/.config/vivaldi/NativeMessagingHosts'
-
-        elif browser == BROWSER.OPERA:
-            native_message_folder = home_address + \
-                '/.config/opera/NativeMessagingHosts'
-
-        elif browser == BROWSER.BRAVE:
-            native_message_folder = home_address + \
-                '/.config/BraveSoftware/Brave-Browser/NativeMessagingHosts'
-        elif browser == "librewolf":
-            native_message_folder = os.path.realpath(os.path.expanduser("~/.librewolf/native-messaging-hosts"))
-
-
-    # for FreeBSD and OpenBSD
-    elif os_type in OS.BSD_FAMILY:
-        # find Persepolis execution path
-        # persepolis intermediate script path
-        intermediary = os.path.join(config_folder, 'persepolis_run_shell')
-
-        if custom_path:
-            native_message_folder = os.path.expanduser(custom_path)
-        elif browser == BROWSER.CHROMIUM:
-            native_message_folder = home_address + '/.config/chromium/NativeMessagingHosts'
-        elif browser == BROWSER.CHROME:
-            native_message_folder = home_address + \
-                '/.config/google-chrome/NativeMessagingHosts'
-
-        elif browser == BROWSER.FIREFOX:
-            native_message_folder = home_address + \
-                '/.mozilla/native-messaging-hosts'
-        elif browser == BROWSER.VIVALDI:
-            native_message_folder = home_address + \
-                '/.config/vivaldi/NativeMessagingHosts'
-
-        elif browser == BROWSER.OPERA:
-            native_message_folder = home_address + \
-                '/.config/opera/NativeMessagingHosts'
-
-        elif browser == BROWSER.BRAVE:
-            native_message_folder = home_address + \
-                '/.config/BraveSoftware/Brave-Browser/NativeMessagingHosts'
-
-    # for Mac OSX
-    elif os_type == OS.OSX:
-        # find Persepolis execution path
-        # persepolis execution path
-        intermediary = os.path.join(config_folder, 'persepolis_run_shell')
-
-        if custom_path:
-            native_message_folder = os.path.expanduser(custom_path)
-
-        elif browser == BROWSER.CHROMIUM:
-            native_message_folder = home_address + \
-                '/Library/Application Support/Chromium/NativeMessagingHosts'
-        elif browser == BROWSER.CHROME:
-            native_message_folder = home_address + \
-                '/Library/Application Support/Google/Chrome/NativeMessagingHosts'
-
-        elif browser == BROWSER.FIREFOX:
-            native_message_folder = home_address + \
-                '/Library/Application Support/Mozilla/NativeMessagingHosts'
-
-        elif browser == BROWSER.VIVALDI:
-            native_message_folder = home_address + \
-                '/Library/Application Support/Vivaldi/NativeMessagingHosts'
-
-        elif browser == BROWSER.OPERA:
-            native_message_folder = home_address + \
-                '/Library/Application Support/Opera/NativeMessagingHosts/'
-
-        elif browser == BROWSER.BRAVE:
-            native_message_folder = home_address + \
-                '/Library/Application Support/BraveSoftware/Brave-Browser/NativeMessagingHosts/'
-        elif browser == "librewolf":
-            native_message_folder = os.path.realpath(os.path.expanduser("~/Library/LibreWolf/NativeMessagingHosts"))
-
-
-    # for MicroSoft Windows os (windows 7 , ...)
+        native_message_folder = get_native_message_folder(browser, custom_path)
     elif os_type == OS.WINDOWS:
+        possible_paths = [
+            os.path.join(os.environ.get('ProgramFiles', ''), 'Persepolis Download Manager', 'PersepolisBI.exe'),
+            os.path.join(os.environ.get('ProgramFiles(x86)', ''), 'Persepolis Download Manager', 'PersepolisBI.exe'),
+        ]
+        intermediary = None
+        for path in possible_paths:
+            if os.path.isfile(path):
+                intermediary = path
+                break
+        if not intermediary:
+            intermediary, logg_message = findExternalAppPath('PersepolisBI')
+            if not os.path.isabs(intermediary):
+                intermediary = os.path.abspath(intermediary)
+        native_message_folder = get_native_message_folder(browser, custom_path)
 
-        # the execution path in json file for Windows must in form of
-        # c:\\Users\\...\\Persepolis Download Manager.exe , so we need 2
-        # "\" in address
-        intermediary, logg_message = findExternalAppPath('PersepolisBI')
-        if custom_path:
-            native_message_folder = os.path.expanduser(custom_path)
-        elif browser == "librewolf":
-            native_message_folder = os.path.realpath(os.path.join(os.environ['APPDATA'], "librewolf", "NativeMessagingHosts"))
-        elif browser in BROWSER.CHROME_FAMILY:
-            native_message_folder = os.path.join(
-                home_address, 'AppData', 'Local',
-                'persepolis_download_manager', 'chrome')
-        else:
-            native_message_folder = os.path.join(
-                home_address, 'AppData', 'Local',
-                'persepolis_download_manager', 'firefox')
-
-    # WebExtension native hosts file prototype
     webextension_json_connector = {
-        "name": "com.persepolis.pdmchromewrapper",
+        "name": f"com.persepolis.{browser.lower()}",
         "type": "stdio",
         "path": str(intermediary),
-        "description": "Integrate Persepolis with %s using WebExtensions" % (browser)
+        "description": f"Integrate Persepolis with {browser} using WebExtensions"
     }
 
-    # Add chrom* keys
-    if browser in BROWSER.CHROME_FAMILY:
-        webextension_json_connector["allowed_origins"] = ["chrome-extension://legimlagjjoghkoedakdjhocbeomojao/"]
 
-    # Add firefox keys
-    elif browser == BROWSER.FIREFOX:
+    # Determine manifest file name and write JSON only once
+    if browser == BROWSER.FIREFOX:
+        webextension_json_connector["name"] = "com.persepolis.firefox"
         webextension_json_connector["allowed_extensions"] = [
             "com.persepolis.pdmchromewrapper@persepolisdm.github.io",
-            "com.persepolis.pdmchromewrapper.offline@persepolisdm.github.io"
+            
         ]
+        manifest_filename = "com.persepolis.firefox.json"
     elif browser == "librewolf":
-        webextension_json_connector["allowed_extensions"] = ["com.persepolis.pdmchromewrapper@persepolisdm.github.io","com.persepolis.pdmchromewrapper.offline@persepolisdm.github.io"]
-    # Build final path
-    native_message_file = os.path.join(
-        native_message_folder, 'com.persepolis.pdmchromewrapper.json')
+        webextension_json_connector["name"] = "com.persepolis.librewolf"
+        webextension_json_connector["allowed_extensions"] = [
+            "com.persepolis.pdmchromewrapper@persepolisdm.github.io",
+        ]
+        manifest_filename = "com.persepolis.librewolf.json"
+    else:
+        if browser in BROWSER.CHROME_FAMILY:
+            webextension_json_connector["allowed_origins"] = ["chrome-extension://legimlagjjoghkoedakdjhocbeomojao/"]
+        manifest_filename = get_manifest_filename(browser)
 
+    native_message_file = os.path.join(native_message_folder, manifest_filename)
     osCommands.makeDirs(native_message_folder)
+    with open(native_message_file, 'w') as f:
+        json.dump(webextension_json_connector, f, indent=2)
 
-    # Write NMH file
-    f = open(native_message_file, 'w')
-    f.write(str(webextension_json_connector).replace("'", "\""))
-    f.close()
+    json_done = False
+    native_done = None
 
     if os_type != OS.WINDOWS:
-
         pipe_json = subprocess.Popen(['chmod', '+x', str(native_message_file)],
                                      stderr=subprocess.PIPE,
                                      stdout=subprocess.PIPE,
                                      stdin=subprocess.PIPE,
                                      shell=False)
-
         if pipe_json.wait() == 0:
             json_done = True
         else:
             json_done = False
-
     else:
-        native_done = None
-        import winreg
-        # add the key to the windows registry
-        if browser in BROWSER.CHROME_FAMILY:
+        # Registry for Chromium-based browsers
+        reg_path = windows_registry_paths.get(browser)
+        if reg_path:
             try:
-                # create pdmchromewrapper key under NativeMessagingHosts
-                winreg.CreateKey(winreg.HKEY_CURRENT_USER,
-                                 "SOFTWARE\\Google\\Chrome\\NativeMessagingHosts\\com.persepolis.pdmchromewrapper")
-                # open a connection to pdmchromewrapper key
-                gintKey = winreg.OpenKey(
-                    winreg.HKEY_CURRENT_USER, "SOFTWARE\\Google\\Chrome\\NativeMessagingHosts\\com.persepolis.pdmchromewrapper", 0, winreg.KEY_ALL_ACCESS)
-                # set native_message_file as key value
+                winreg.CreateKey(winreg.HKEY_CURRENT_USER, reg_path)
+                gintKey = winreg.OpenKey(winreg.HKEY_CURRENT_USER, reg_path, 0, winreg.KEY_ALL_ACCESS)
                 winreg.SetValueEx(gintKey, '', 0, winreg.REG_SZ, native_message_file)
-                # close connection to pdmchromewrapper
                 winreg.CloseKey(gintKey)
-
                 json_done = True
-
-            except WindowsError:
-
+            except OSError:
                 json_done = False
-
-        elif browser == BROWSER.FIREFOX:
+        # Registry for Firefox and LibreWolf
+        elif browser == BROWSER.FIREFOX or browser == "librewolf":
+            reg_path = windows_registry_paths.get(browser)
             try:
-                # create pdmchromewrapper key under NativeMessagingHosts for firefox
-                winreg.CreateKey(winreg.HKEY_CURRENT_USER,
-                                 "SOFTWARE\\Mozilla\\NativeMessagingHosts\\com.persepolis.pdmchromewrapper")
-                # open a connection to pdmchromewrapper key for firefox
+                winreg.CreateKey(winreg.HKEY_CURRENT_USER, reg_path)
                 fintKey = winreg.OpenKey(
-                    winreg.HKEY_CURRENT_USER, "SOFTWARE\\Mozilla\\NativeMessagingHosts\\com.persepolis.pdmchromewrapper", 0, winreg.KEY_ALL_ACCESS)
-                # set native_message_file as key value
+                    winreg.HKEY_CURRENT_USER, reg_path, 0, winreg.KEY_ALL_ACCESS)
                 winreg.SetValueEx(fintKey, '', 0, winreg.REG_SZ, native_message_file)
-                # close connection to pdmchromewrapper
                 winreg.CloseKey(fintKey)
-
                 json_done = True
-
-            except WindowsError:
-
+            except OSError:
                 json_done = False
 
-    # create persepolis_run_shell(intermediate script) file for gnu/linux and BSD and Mac
-    # firefox and chromium and ... call persepolis with Native Messaging system.
-    # json file calls persepolis_run_shell file.
     if os_type in OS.UNIX_LIKE or os_type == OS.OSX:
-        # find available shell
         shell_list = ['/bin/bash', '/usr/local/bin/bash', '/bin/sh', '/usr/local/bin/sh', '/bin/ksh', '/bin/tcsh']
-
+        shebang = ''
         for shell in shell_list:
             if os.path.isfile(shell):
-                # define shebang
                 shebang = '#!' + shell
                 break
-
         persepolis_run_shell_contents = shebang + '\n' + "python3 -m persepolis \"$@\""
-        f = open(intermediary, 'w')
-        f.writelines(persepolis_run_shell_contents)
-        f.close()
-
-        # make persepolis_run_shell executable
-
+        with open(intermediary, 'w') as f:
+            f.writelines(persepolis_run_shell_contents)
         pipe_native = subprocess.Popen(['chmod', '+x', intermediary],
                                        stderr=subprocess.PIPE,
                                        stdout=subprocess.PIPE,
                                        stdin=subprocess.PIPE,
                                        shell=False)
-
         if pipe_native.wait() == 0:
             native_done = True
         else:
@@ -273,41 +158,22 @@ def browserIntegration(browser, custom_path=None):
     return json_done, native_done, logg_message
 
 
-def install_native_hosts(browsers, custom_path=None):
+def get_manifest_filename(browser):
+    return f"com.persepolis.{browser.lower()}.json"
 
-    log_messages = []
-    for browser in browsers:
-        try:
-            json_done, native_done, log = browserIntegration(browser, custom_path)
-            log_messages.append(f"[{browser}] JSON: {json_done}, Native: {native_done}")
-        except Exception as e:
-            log_messages.append(f"[{browser}] Failed: {str(e)}")
 
-    return log_messages
 def get_manifest_path_for_browser(browser, custom_path=None):
     folder = get_native_message_folder(browser, custom_path)
     if not folder:
         return None
-    return os.path.join(folder, 'com.persepolis.pdmchromewrapper.json')
+    return os.path.join(folder, get_manifest_filename(browser))
 
-
-def remove_manifests_for_browsers(browsers, custom_path=None):
-    for browser in browsers:
-        try:
-            if browser.strip() == "":
-                continue
-            path = get_manifest_path_for_browser(browser, custom_path)
-            if path and os.path.exists(path):
-                os.remove(path)
-                print(f"Removed manifest for {browser}: {path}")
-        except Exception as e:
-            print(f"Failed to remove manifest for {browser}: {e}")
 
 def get_native_message_folder(browser, custom_path=None):
     if custom_path:
         return os.path.expanduser(custom_path)
 
-    if os_type == OS.LINUX:
+    if os_type == OS.LINUX or os_type in OS.BSD_FAMILY:
         if browser == BROWSER.CHROMIUM:
             return os.path.join(home_address, '.config/chromium/NativeMessagingHosts')
         elif browser == BROWSER.CHROME:
@@ -342,7 +208,7 @@ def get_native_message_folder(browser, custom_path=None):
     elif os_type == OS.WINDOWS:
         if browser == "librewolf":
             return os.path.join(os.environ['LOCALAPPDATA'], "Librewolf", "NativeMessagingHosts")
-        elif browser in BROWSER.CHROMIUM:
+        elif browser == BROWSER.CHROMIUM:
             return os.path.join(os.environ['LOCALAPPDATA'], "Chromium", "User Data", "NativeMessagingHosts")
         elif browser == BROWSER.FIREFOX:
             return os.path.join(os.environ['LOCALAPPDATA'],  "Mozilla", "NativeMessagingHosts")
@@ -354,5 +220,41 @@ def get_native_message_folder(browser, custom_path=None):
             return os.path.join(os.environ['LOCALAPPDATA'],  "Opera Software", "Opera Stable", "NativeMessagingHosts")
         elif browser == BROWSER.VIVALDI:
             return os.path.join(os.environ['LOCALAPPDATA'],  "Vivaldi", "User Data", "NativeMessagingHosts")
-
     return None
+
+
+def remove_registry_key(browser):
+    reg_path = windows_registry_paths.get(browser)
+    if reg_path:
+        try:
+            winreg.DeleteKey(winreg.HKEY_CURRENT_USER, reg_path)
+        except FileNotFoundError:
+            pass
+        except OSError as e:
+            print(f"Failed to remove registry key for {browser}: {e}")
+
+
+def remove_manifests_for_browsers(browsers, custom_path=None):
+    for browser in browsers:
+        try:
+            if browser.strip() == "":
+                continue
+            path = get_manifest_path_for_browser(browser, custom_path)
+            if path and os.path.exists(path):
+                os.remove(path)
+                print(f"Removed manifest for {browser}: {path}")
+            if os_type == OS.WINDOWS:
+                remove_registry_key(browser)
+        except Exception as e:
+            print(f"Failed to remove manifest for {browser}: {e}")
+
+
+def install_native_hosts(browsers, custom_path=None):
+    log_messages = []
+    for browser in browsers:
+        try:
+            json_done, native_done, log = browserIntegration(browser, custom_path)
+            log_messages.append(f"[{browser}] JSON: {json_done}, Native: {native_done}")
+        except Exception as e:
+            log_messages.append(f"[{browser}] Failed: {str(e)}")
+    return log_messages

--- a/persepolis/scripts/browser_integration.py
+++ b/persepolis/scripts/browser_integration.py
@@ -297,11 +297,12 @@ def remove_manifests_for_browsers(browsers, custom_path=None):
             if browser.strip() == "":
                 continue
             path = get_manifest_path_for_browser(browser, custom_path)
-            if os.path.exists(path):
+            if path and os.path.exists(path):
                 os.remove(path)
                 print(f"Removed manifest for {browser}: {path}")
         except Exception as e:
             print(f"Failed to remove manifest for {browser}: {e}")
+
 def get_native_message_folder(browser, custom_path=None):
     if custom_path:
         return os.path.expanduser(custom_path)
@@ -322,7 +323,36 @@ def get_native_message_folder(browser, custom_path=None):
         elif browser == "librewolf":
             return os.path.join(home_address, '.librewolf/native-messaging-hosts')
 
-    # (You can add Windows/macOS as needed)
+    elif os_type == OS.OSX:
+        if browser == BROWSER.CHROMIUM:
+            return os.path.join(home_address, 'Library/Application Support/Chromium/NativeMessagingHosts')
+        elif browser == BROWSER.CHROME:
+            return os.path.join(home_address, 'Library/Application Support/Google/Chrome/NativeMessagingHosts')
+        elif browser == BROWSER.FIREFOX:
+            return os.path.join(home_address, 'Library/Application Support/Mozilla/NativeMessagingHosts')
+        elif browser == BROWSER.VIVALDI:
+            return os.path.join(home_address, 'Library/Application Support/Vivaldi/NativeMessagingHosts')
+        elif browser == BROWSER.OPERA:
+            return os.path.join(home_address, 'Library/Application Support/Opera/NativeMessagingHosts')
+        elif browser == BROWSER.BRAVE:
+            return os.path.join(home_address, 'Library/Application Support/BraveSoftware/Brave-Browser/NativeMessagingHosts')
+        elif browser == "librewolf":
+            return os.path.join(home_address, 'Library/LibreWolf/NativeMessagingHosts')
+
+    elif os_type == OS.WINDOWS:
+        if browser == "librewolf":
+            return os.path.join(os.environ['LOCALAPPDATA'], "Librewolf", "NativeMessagingHosts")
+        elif browser in BROWSER.CHROMIUM:
+            return os.path.join(os.environ['LOCALAPPDATA'], "Chromium", "User Data", "NativeMessagingHosts")
+        elif browser == BROWSER.FIREFOX:
+            return os.path.join(os.environ['LOCALAPPDATA'],  "Mozilla", "NativeMessagingHosts")
+        elif browser == BROWSER.CHROME:
+            return os.path.join(os.environ['LOCALAPPDATA'], "Google", "Chrome", "User Data", "NativeMessagingHosts")
+        elif browser == BROWSER.BRAVE:
+            return os.path.join(os.environ['LOCALAPPDATA'],  "BraveSoftware", "Brave-Browser", "User Data", "NativeMessagingHosts")
+        elif browser == BROWSER.OPERA:
+            return os.path.join(os.environ['LOCALAPPDATA'],  "Opera Software", "Opera Stable", "NativeMessagingHosts")
+        elif browser == BROWSER.VIVALDI:
+            return os.path.join(os.environ['LOCALAPPDATA'],  "Vivaldi", "User Data", "NativeMessagingHosts")
 
     return None
-

--- a/persepolis/scripts/browser_integration.py
+++ b/persepolis/scripts/browser_integration.py
@@ -299,9 +299,9 @@ def remove_manifests_for_browsers(browsers, custom_path=None):
             path = get_manifest_path_for_browser(browser, custom_path)
             if os.path.exists(path):
                 os.remove(path)
-                print(f"🗑 Removed manifest for {browser}: {path}")
+                print(f"Removed manifest for {browser}: {path}")
         except Exception as e:
-            print(f"⚠️ Failed to remove manifest for {browser}: {e}")
+            print(f"Failed to remove manifest for {browser}: {e}")
 def get_native_message_folder(browser, custom_path=None):
     if custom_path:
         return os.path.expanduser(custom_path)


### PR DESCRIPTION
## Summary

This PR adds a new **Browser Integration** tab in the Persepolis settings, giving users control over which browsers are integrated via native messaging.

### Features:
1. Users can now explicitly select browsers (Firefox, LibreWolf, Chrome, etc.) to integrate with Persepolis.
2. When a browser is unselected, its corresponding native messaging manifest is automatically removed.
3. Manifests are no longer created unnecessarily. Integration is now **opt-in**.
4. The list of browsers is shown even if not installed (but auto-check only if installed).
5. GUI checkboxes reflect real integration status.
6. Custom manifest path is supported.
- Changes made to: `initialization.py`, `setting_ui.py`, `setting.py`, `browser_integration.py`


 Tested on Linux (LibreWolf, Firefox). Requires clean config reset for testing.