### PR TITLE
Add portable mode support for Persepolis

### DIFF
--- a/persepolis/gui/customized_widgets.py
+++ b/persepolis/gui/customized_widgets.py
@@ -20,8 +20,10 @@ except ImportError:
     from PyQt5.QtWidgets import QDateTimeEdit
     from PyQt5.QtCore import QSettings, Qt
 
+from persepolis.scripts.useful_tools import createQSettings
+
 # import persepolis_setting
-persepolis_setting = QSettings('persepolis_download_manager', 'persepolis')
+persepolis_setting = createQSettings()
 
 # check ui_direction RTL or LTR
 ui_direction = persepolis_setting.value('ui_direction')

--- a/persepolis/scripts/bubble.py
+++ b/persepolis/scripts/bubble.py
@@ -147,7 +147,8 @@ def notifySend(message1, message2, time, sound, parent=None):
         playNotification(file)
 
     # load settings
-    persepolis_setting = QSettings('persepolis_download_manager', 'persepolis')
+    from persepolis.scripts.useful_tools import createQSettings
+    persepolis_setting = createQSettings()
 
     enable_notification = persepolis_setting.value('settings/notification')
 

--- a/persepolis/scripts/error_window.py
+++ b/persepolis/scripts/error_window.py
@@ -90,6 +90,7 @@ class ErrorWindow(QWidget):
         persepolis_db.closeConnections()
 
         # Reset persepolis_setting
-        persepolis_setting = QSettings('persepolis_download_manager', 'persepolis')
+        from persepolis.scripts.useful_tools import createQSettings
+        persepolis_setting = createQSettings()
         persepolis_setting.clear()
         persepolis_setting.sync()

--- a/persepolis/scripts/initialization.py
+++ b/persepolis/scripts/initialization.py
@@ -18,7 +18,7 @@
 
 from persepolis.scripts.data_base import PersepolisDB, PluginsDB
 from persepolis.scripts import logger
-from persepolis.scripts.useful_tools import determineConfigFolder, returnDefaultSettings, osAndDesktopEnvironment, getExecPath
+from persepolis.scripts.useful_tools import determineConfigFolder, returnDefaultSettings, osAndDesktopEnvironment, getExecPath, isPortableMode, createQSettings
 from persepolis.scripts.browser_integration import browserIntegration
 from persepolis.scripts import osCommands
 from persepolis.constants import OS
@@ -113,7 +113,7 @@ plugins_db.closeConnections()
 # persepolis is using QSettings for saving windows size and windows
 # position and program settings.
 
-persepolis_setting = QSettings('persepolis_download_manager', 'persepolis')
+persepolis_setting = createQSettings()
 
 persepolis_setting.beginGroup('settings')
 
@@ -150,27 +150,30 @@ for folder in folder_list:
 persepolis_setting.endGroup()
 
 # Browser integration for Firefox and chromium and google chrome
-persepolis_setting.beginGroup('settings/native_messaging')
-for browser in ['chrome', 'chromium', 'opera', 'vivaldi', 'firefox', 'brave', 'librewolf']:
-    if persepolis_setting.value(browser) == 'true':
-        json_done, intermediary_done, logg_message2 = browserIntegration(browser)
-        logg_message = browser
+if isPortableMode():
+    logger.sendToLog("Browser integration is disabled in portable mode.", 'INITIALIZATION')
+else:
+    persepolis_setting.beginGroup('settings/native_messaging')
+    for browser in ['chrome', 'chromium', 'opera', 'vivaldi', 'firefox', 'brave', 'librewolf']:
+        if persepolis_setting.value(browser) == 'true':
+            json_done, intermediary_done, logg_message2 = browserIntegration(browser)
+            logg_message = browser
 
-        if json_done is True:
-            logg_message = logg_message + ': ' + 'Json file is created successfully.\n'
+            if json_done is True:
+                logg_message = logg_message + ': ' + 'Json file is created successfully.\n'
 
-        else:
-            logg_message = logg_message + ': ' + 'Json ERROR!\n'
+            else:
+                logg_message = logg_message + ': ' + 'Json ERROR!\n'
 
-        if intermediary_done is True:
-            logg_message = logg_message + 'persepolis intermediary file is created successfully.\n'
+            if intermediary_done is True:
+                logg_message = logg_message + 'persepolis intermediary file is created successfully.\n'
 
-        elif intermediary_done is False:
-            logg_message = logg_message + ': ' + 'persepolis executer file ERROR!\n'
+            elif intermediary_done is False:
+                logg_message = logg_message + ': ' + 'persepolis executer file ERROR!\n'
 
-        logger.sendToLog(logg_message, 'INITIALIZATION')
-        logger.sendToLog(logg_message2, 'INITIALIZATION')
-persepolis_setting.endGroup()
+            logger.sendToLog(logg_message, 'INITIALIZATION')
+            logger.sendToLog(logg_message2, 'INITIALIZATION')
+    persepolis_setting.endGroup()
 # get locale and set ui direction
 locale = str(persepolis_setting.value('settings/locale'))
 

--- a/persepolis/scripts/persepolis.py
+++ b/persepolis/scripts/persepolis.py
@@ -30,7 +30,7 @@ import json
 import struct
 import argparse
 from persepolis.scripts import osCommands
-from persepolis.scripts.useful_tools import osAndDesktopEnvironment, determineConfigFolder
+from persepolis.scripts.useful_tools import osAndDesktopEnvironment, determineConfigFolder, isPortableMode, setForcePortableMode, getPortableBaseDir, createQSettings
 from persepolis.constants import OS
 from persepolis.constants import VERSION
 from copy import deepcopy
@@ -47,6 +47,19 @@ if os_type in (OS.UNIX_LIKE + [OS.OSX]):
         print('Do not run persepolis as root.')
         sys.exit(1)
 
+
+# Early check for --portable flag before any config folder is computed.
+# This must happen before determineConfigFolder() is called.
+if '--portable' in sys.argv:
+    setForcePortableMode(True)
+    # Create the portable marker file if it doesn't already exist
+    _portable_base = getPortableBaseDir()
+    if _portable_base is not None:
+        _marker_path = os.path.join(_portable_base, 'portable')
+        if not os.path.isfile(_marker_path):
+            os.makedirs(_portable_base, exist_ok=True)
+            with open(_marker_path, 'w') as f:
+                f.write('# Portable mode marker file for Persepolis Download Manager\n')
 
 # initialization
 # find home address
@@ -86,7 +99,14 @@ else:  # for windows
     from win32api import GetLastError
     from winerror import ERROR_ALREADY_EXISTS
 
-    handle = CreateMutex(None, 1, 'persepolis_download_manager')
+    if isPortableMode():
+        import hashlib
+        path_hash = hashlib.md5(config_folder.encode()).hexdigest()[:8]
+        mutex_name = 'persepolis_download_manager_portable_' + path_hash
+    else:
+        mutex_name = 'persepolis_download_manager'
+
+    handle = CreateMutex(None, 1, mutex_name)
 
     if GetLastError() == ERROR_ALREADY_EXISTS:
         lock_file_validation = False
@@ -111,7 +131,7 @@ if lock_file_validation:
 
 
 # load persepolis_settings
-persepolis_setting = QSettings('persepolis_download_manager', 'persepolis')
+persepolis_setting = createQSettings()
 
 
 class PersepolisApplication(QtWidgets.QApplication):
@@ -164,12 +184,15 @@ parser.add_argument('--tray', action='store_true',
                     help="Persepolis is starting in tray icon. It's useful when you want to put persepolis in system's startup.")
 parser.add_argument('--parent-window', action='store', nargs=1,
                     help='this switch is used for chrome native messaging in Windows')
+parser.add_argument('--portable', action='store_true',
+                    help='Run in portable mode: store all data in the application directory.')
 parser.add_argument('--version', action='version', version='Persepolis Download Manager ' + VERSION.version_str)
 
 
 # Clears unwanted args ( like args from Browers via NHM )
 # unknown arguments (may sent by browser) will save in unknownargs.
 args, unknownargs = parser.parse_known_args()
+
 
 # if --execute >> yes  >>> persepolis main window  will start.
 # if --execute >> no >>> persepolis started before!
@@ -424,7 +447,7 @@ def main():
         persepolis_download_manager.setApplicationVersion(VERSION.version_str)
 
         # Persepolis setting
-        persepolis_download_manager.setting = QSettings('persepolis_download_manager', 'persepolis')
+        persepolis_download_manager.setting = createQSettings()
 
         # get user's desired font and style , ... from setting
         custom_font = persepolis_download_manager.setting.value('settings/custom-font')

--- a/persepolis/scripts/play.py
+++ b/persepolis/scripts/play.py
@@ -19,6 +19,7 @@ except ImportError:
     from PyQt5.QtCore import QUrl, QSettings
     from PyQt5.QtMultimedia import QSoundEffect
 
+from persepolis.scripts.useful_tools import createQSettings
 from persepolis.scripts import logger
 from persepolis.constants import OS
 import platform
@@ -33,7 +34,7 @@ global effect
 
 def playNotification(file):
     # getting user setting from persepolis_setting
-    persepolis_setting = QSettings('persepolis_download_manager', 'persepolis')
+    persepolis_setting = createQSettings()
 
     # enabling or disabling notification sound in persepolis_setting
     enable_notification = str(persepolis_setting.value('settings/sound'))

--- a/persepolis/scripts/spider.py
+++ b/persepolis/scripts/spider.py
@@ -13,7 +13,7 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from persepolis.scripts.useful_tools import humanReadableSize, headerToDict, readCookieJar, getFileNameFromLink
+from persepolis.scripts.useful_tools import humanReadableSize, headerToDict, readCookieJar, getFileNameFromLink, createQSettings
 from persepolis.constants import VERSION
 import requests
 try:
@@ -26,7 +26,7 @@ except ImportError:
 # http://docs.python-requests.org/en/master/
 
 # load persepolis_settings
-persepolis_setting = QSettings('persepolis_download_manager', 'persepolis')
+persepolis_setting = createQSettings()
 # check certificate
 if str(persepolis_setting.value('settings/dont-check-certificate')) == 'yes':
     check_certificate = False

--- a/persepolis/scripts/useful_tools.py
+++ b/persepolis/scripts/useful_tools.py
@@ -24,6 +24,9 @@ import time
 import sys
 import os
 
+# Global flag that can be set by --portable CLI argument before modules are imported.
+_force_portable_mode = False
+
 try:
     from PySide6.QtCore import QThread, Signal, QProcess
     from PySide6.QtWidgets import QStyleFactory
@@ -63,10 +66,162 @@ class RunApplicationThread(QThread):
         if self.call_back:
             self.RUNAPPCALLBACKSIGNAL.emit([pipe])
 
+# This function returns persepolis's execution path.
+def getExecPath():
+
+    exec_dictionary = {'bundle': None,
+                       'test': False,
+                       'exec_file_path': None,
+                       'modified_exec_file_path': None}
+
+    # check if persepolis is run as a bundle.
+    # On Windows and Mac we use pyinstaller to build the bundle,
+    # and on Linux and BSD we use nuitka.
+    # the output of this code for pyinstaller bundle is True
+    # getattr(sys, 'frozen', False) and hasattr(sys, '_MEIPASS')
+    # But this code doesn't work for nuitka!
+    # So we have to use a workaround to identify nuitka bundle.
+    # We check the inside of the bundle and look for the
+    # com.github.persepolisdm.persepolis.svg file(icon).
+    # file that we placed. If it was, then the bundle file
+    # generated with nuitka is running.
+    if os_type in OS.UNIX_LIKE:
+        bundle_path = os.path.dirname(sys.executable)
+        icon_file_path = os.path.join(bundle_path, 'com.github.persepolisdm.persepolis.svg')
+
+        # check availability of com.github.persepolisdm.persepolis.svg
+        if os.path.exists(icon_file_path):
+            exec_dictionary['bundle'] = True
+
+            # for nuitka
+            # get executable path
+            bundle_path = os.path.abspath(sys.argv[0])
+
+            exec_file_path = bundle_path
+
+    # for windows and osx(pyinstaller bundle)
+    else:
+        # check pyinstaller bundle
+        if getattr(sys, 'frozen', False) and hasattr(sys, '_MEIPASS'):
+            exec_dictionary['bundle'] = True
+            # get executable path
+            bundle_path = os.path.dirname(sys.executable)
+
+            # get bundle name
+            bundle_name = os.path.basename(sys.executable)
+
+            exec_file_path = os.path.join(bundle_path, bundle_name)
+
+    if exec_dictionary['bundle'] is not True:
+
+        # persepolis is run from python script
+        exec_dictionary['bundle'] = False
+
+        # get execution path
+        script_path = os.path.dirname(os.path.abspath(sys.modules['__main__'].__file__))
+        script_name = os.path.basename(sys.argv[0])
+
+        if script_name == 'test.py':
+
+            # persepolis is run from test directory
+            exec_dictionary['test'] = True
+
+        exec_file_path = os.path.join(script_path, script_name)
+
+    # replace space with \+space for UNIX_LIKE and OSX
+    if os_type in OS.UNIX_LIKE or os_type == OS.OSX:
+
+        modified_exec_file_path = exec_file_path.replace(" ", r"\ ")
+
+    elif os_type == OS.WINDOWS:
+        modified_exec_file_path = exec_file_path.replace('\\', r'\\')
+
+    # write it in dictionary
+    exec_dictionary['exec_file_path'] = exec_file_path
+    exec_dictionary['modified_exec_file_path'] = modified_exec_file_path
+
+    # return ressults
+    return exec_dictionary
+
+
+def _getPortableMarkerDir():
+    """
+    Returns the directory containing the 'portable' marker file if portable mode
+    is active, otherwise returns None.
+
+    Portable mode is active when:
+    - The global _force_portable_mode flag is set (via --portable CLI arg), OR
+    - A file named 'portable' exists in the same directory as the running
+      executable (bundle) or the top-level package directory (development mode).
+    """
+    global _force_portable_mode
+
+    exec_info = getExecPath()
+
+    # Determine candidate directories to check for the 'portable' marker
+    candidate_dirs = []
+
+    if exec_info['bundle']:
+        # Running as a compiled bundle — check alongside the executable
+        candidate_dirs.append(os.path.dirname(exec_info['exec_file_path']))
+    else:
+        # Running from source or installed — check alongside the top-level
+        # persepolis package directory (i.e., the repo root)
+        package_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        candidate_dirs.append(package_dir)
+
+    for directory in candidate_dirs:
+        marker = os.path.join(directory, 'portable')
+        if os.path.isfile(marker) or _force_portable_mode:
+            return directory
+
+    return None
+
+
+def isPortableMode():
+    """Returns True if the application is running in portable mode."""
+    return _getPortableMarkerDir() is not None
+
+
+def setForcePortableMode(enabled=True):
+    """Set by --portable CLI argument to force portable mode."""
+    global _force_portable_mode
+    _force_portable_mode = enabled
+
+
+def getPortableBaseDir():
+    """Returns the base directory for portable mode, or None if not in portable mode."""
+    return _getPortableMarkerDir()
+
+
+def createQSettings():
+    """Create and return the application QSettings object.
+
+    In portable mode, uses an INI file in the portable data directory.
+    In normal mode, uses the platform default (registry on Windows, etc.).
+    """
+    try:
+        from PySide6.QtCore import QSettings
+    except ImportError:
+        from PyQt5.QtCore import QSettings
+
+    if isPortableMode():
+        settings_file = os.path.join(determineConfigFolder(), 'settings.ini')
+        return QSettings(settings_file, QSettings.Format.IniFormat)
+    else:
+        return QSettings('persepolis_download_manager', 'persepolis')
+
+
 # determine the config folder path based on the operating system
 
 
 def determineConfigFolder():
+    # Check for portable mode first
+    portable_dir = _getPortableMarkerDir()
+    if portable_dir is not None:
+        return os.path.join(portable_dir, 'persepolis_data')
+
+    # Standard (non-portable) paths
     if os_type in OS.UNIX_LIKE:
         config_folder = os.path.join(
             home_address, ".config/persepolis_download_manager")
@@ -195,7 +350,10 @@ def returnDefaultSettings():
     os_type, desktop_env = osAndDesktopEnvironment()
 
     # user download folder path
-    download_path = os.path.join(home_address, 'Downloads', 'Persepolis')
+    if isPortableMode():
+        download_path = os.path.join(determineConfigFolder(), 'Downloads')
+    else:
+        download_path = os.path.join(home_address, 'Downloads', 'Persepolis')
 
     # set dark fusion for default style settings.
     style = 'Fusion'
@@ -509,84 +667,6 @@ def findExternalAppPath(app_name):
         log_list = ["Persepolis will use {} that installed on user's system.".format(app_name), "INFO"]
 
     return app_command, log_list
-
-
-# This function returns persepolis's execution path.
-def getExecPath():
-
-    exec_dictionary = {'bundle': None,
-                       'test': False,
-                       'exec_file_path': None,
-                       'modified_exec_file_path': None}
-
-    # check if persepolis is run as a bundle.
-    # On Windows and Mac we use pyinstaller to build the bundle,
-    # and on Linux and BSD we use nuitka.
-    # the output of this code for pyinstaller bundle is True
-    # getattr(sys, 'frozen', False) and hasattr(sys, '_MEIPASS')
-    # But this code doesn't work for nuitka!
-    # So we have to use a workaround to identify nuitka bundle.
-    # We check the inside of the bundle and look for the
-    # com.github.persepolisdm.persepolis.svg file(icon).
-    # file that we placed. If it was, then the bundle file
-    # generated with nuitka is running.
-    if os_type in OS.UNIX_LIKE:
-        bundle_path = os.path.dirname(sys.executable)
-        icon_file_path = os.path.join(bundle_path, 'com.github.persepolisdm.persepolis.svg')
-
-        # check availability of com.github.persepolisdm.persepolis.svg
-        if os.path.exists(icon_file_path):
-            exec_dictionary['bundle'] = True
-
-            # for nuitka
-            # get executable path
-            bundle_path = os.path.abspath(sys.argv[0])
-
-            exec_file_path = bundle_path
-
-    # for windows and osx(pyinstaller bundle)
-    else:
-        # check pyinstaller bundle
-        if getattr(sys, 'frozen', False) and hasattr(sys, '_MEIPASS'):
-            exec_dictionary['bundle'] = True
-            # get executable path
-            bundle_path = os.path.dirname(sys.executable)
-
-            # get bundle name
-            bundle_name = os.path.basename(sys.executable)
-
-            exec_file_path = os.path.join(bundle_path, bundle_name)
-
-    if exec_dictionary['bundle'] is not True:
-
-        # persepolis is run from python script
-        exec_dictionary['bundle'] = False
-
-        # get execution path
-        script_path = os.path.dirname(os.path.abspath(sys.modules['__main__'].__file__))
-        script_name = os.path.basename(sys.argv[0])
-
-        if script_name == 'test.py':
-
-            # persepolis is run from test directory
-            exec_dictionary['test'] = True
-
-        exec_file_path = os.path.join(script_path, script_name)
-
-    # replace space with \+space for UNIX_LIKE and OSX
-    if os_type in OS.UNIX_LIKE or os_type == OS.OSX:
-
-        modified_exec_file_path = exec_file_path.replace(" ", r"\ ")
-
-    elif os_type == OS.WINDOWS:
-        modified_exec_file_path = exec_file_path.replace('\\', r'\\')
-
-    # write it in dictionary
-    exec_dictionary['exec_file_path'] = exec_file_path
-    exec_dictionary['modified_exec_file_path'] = modified_exec_file_path
-
-    # return ressults
-    return exec_dictionary
 
 
 # This method returns data and time in string format

--- a/portable.example
+++ b/portable.example
@@ -1,0 +1,3 @@
+# Rename this file to 'portable' (remove the .example suffix) to enable portable mode.
+# When active, all Persepolis data (settings, database, downloads) will be stored
+# in the 'persepolis_data' folder next to this file instead of your home directory.

--- a/resources/PersepolisBI.py
+++ b/resources/PersepolisBI.py
@@ -37,9 +37,20 @@ os_type = platform.system()
 # user home address
 home_address = os.path.expanduser("~")
 
-# persepolis config folder in M.S Windows
-config_folder = os.path.join(
-    home_address, 'AppData', 'Local', 'persepolis_download_manager')
+# Check for portable mode: look for 'portable' marker file alongside the executable
+_portable_dir = None
+if getattr(sys, 'frozen', False):
+    _exe_dir = os.path.dirname(sys.executable)
+else:
+    _exe_dir = os.path.dirname(os.path.abspath(__file__))
+
+if os.path.isfile(os.path.join(_exe_dir, 'portable')):
+    _portable_dir = _exe_dir
+    config_folder = os.path.join(_portable_dir, 'persepolis_data')
+else:
+    # persepolis config folder in M.S Windows
+    config_folder = os.path.join(
+        home_address, 'AppData', 'Local', 'persepolis_download_manager')
 
 # create folder if it's not exist.
 os.makedirs(config_folder, exist_ok=True)
@@ -48,7 +59,11 @@ os.makedirs(config_folder, exist_ok=True)
 persepolis_tmp = os.path.join(config_folder, 'persepolis_tmp')
 
 # load persepolis_settings
-persepolis_setting = QSettings('persepolis_download_manager', 'persepolis')
+if _portable_dir is not None:
+    _settings_file = os.path.join(config_folder, 'settings.ini')
+    persepolis_setting = QSettings(_settings_file, QSettings.Format.IniFormat)
+else:
+    persepolis_setting = QSettings('persepolis_download_manager', 'persepolis')
 
 
 # plugins.db is store links, when browser plugins are send new links.


### PR DESCRIPTION
## Summary
This PR adds portable mode support to Persepolis, allowing the application to store all configuration, settings, and download data in a directory alongside the executable rather than in the user's home directory. This is useful for running Persepolis from USB drives or other portable storage.

## Key Changes

- **Portable mode detection**: Added `_getPortableMarkerDir()`, `isPortableMode()`, and `setForcePortableMode()` functions to detect and manage portable mode via a `portable` marker file or `--portable` CLI argument
- **Centralized QSettings creation**: Introduced `createQSettings()` function that returns platform-appropriate QSettings (INI file in portable mode, registry/defaults in normal mode)
- **Config folder redirection**: Modified `determineConfigFolder()` to return `persepolis_data` subdirectory when in portable mode
- **Download path adjustment**: Updated `returnDefaultSettings()` to use portable data directory for downloads in portable mode
- **CLI argument support**: Added `--portable` command-line flag that forces portable mode and creates the marker file if needed
- **Windows mutex isolation**: Modified Windows mutex naming to include a hash of the config path in portable mode, allowing multiple portable instances to run simultaneously
- **Browser integration disable**: Disabled browser native messaging integration in portable mode to avoid system-wide registry/config modifications
- **Early initialization**: Added early portable mode detection in `persepolis.py` before any config folders are computed
- **Consistent QSettings usage**: Updated all QSettings instantiations across the codebase to use `createQSettings()` for consistency
- **Browser integration script support**: Added portable mode detection to `PersepolisBI.py` for the browser integration helper

## Implementation Details

- The portable marker file is created automatically when `--portable` is used if it doesn't already exist
- Portable mode works with both bundled (PyInstaller/Nuitka) and source installations
- The `portable.example` file serves as documentation for manual portable mode activation
- All data paths (settings, database, downloads) are redirected to the `persepolis_data` subdirectory in portable mode
- The implementation maintains backward compatibility with existing non-portable installations
