### PR TITLE
fix: delete corrupted control file to allow proper resume

### DIFF
--- a/persepolis/scripts/persepolis_lib_prime.py
+++ b/persepolis/scripts/persepolis_lib_prime.py
@@ -342,6 +342,10 @@ class Download():
                     except Exception as e:
                         logger.sendToLog(str(e) + ' - GID: ' + self.gid, 'DOWNLOAD ERROR')
                         self.resume = False
+                        try:
+                            os.remove(self.control_json_file_path)
+                        except:
+                            pass
 
         if self.resuming_suppurt is False:
             self.resume = False


### PR DESCRIPTION
EN:
When a download is interrupted and restarted, if the .persepolis control file is corrupted (e.g. due to a crash or power loss), json.load() throws an exception. The code sets resume = False but doesn't delete the corrupted control file. On the next attempt, the file still exists and causes the download to get stuck on "creating download file" instead of resuming or starting fresh.
Fix: Delete the corrupted control file in the exception handler so the next run can create a clean one.


FA:
وقتی یه دانلود قطع میشه و دوباره شروع میشه، اگه فایل کنترل .persepolis خراب باشه (مثلاً به خاطر کرش یا قطع برق)، تابع json.load() خطا میده. کد resume = False میکنه ولی فایل خراب رو پاک نمیکنه. در نتیجه دانلود گیر میکنه روی "creating download file" و نه resume میکنه نه از صفر شروع میکنه.
راه‌حل: فایل کنترل خراب رو توی exception handler پاک کن تا دفعه بعد یه فایل تمیز ساخته بشه.