### PR TITLE
fix: avoid spamming NewToolTip D-Bus signals on Wayland

### DIFF
--- a/persepolis/scripts/mainwindow.py
+++ b/persepolis/scripts/mainwindow.py
@@ -1546,7 +1546,11 @@ class MainWindow(MainWindow_Ui):
                         self.temp_db.updateSingleTable(shutdown_dict)
 
         # set tooltip for system_tray_icon
-        self.system_tray_icon.setToolTip(systemtray_tooltip_text)
+        # # Only update when the text actually changes to avoid spamming
+        # org.kde.StatusNotifierItem.NewToolTip D-Bus signals.
+        if getattr(self, '_last_systemtray_tooltip', None) != systemtray_tooltip_text:
+            self.system_tray_icon.setToolTip(systemtray_tooltip_text)
+            self._last_systemtray_tooltip = systemtray_tooltip_text
 
     # drag and drop for links
     def dragEnterEvent(self, droplink):


### PR DESCRIPTION
## Problem

`checkDownloadInfo()` runs every 200 ms and unconditionally calls `QSystemTrayIcon.setToolTip()`. On Wayland, Qt's StatusNotifierItem backend emits a `NewToolTip` D-Bus signal on every call, flooding the session bus with ~5 signals per second even when no downloads are active.

This causes SNI-based tray hosts such as Waybar to stop displaying tooltips for all tray items while Persepolis is running.

## Fix

Only call `setToolTip()` when the tooltip text has actually changed. This keeps the download-progress tooltip working but eliminates the redundant D-Bus traffic.

## Testing

- Run Persepolis from source with `python3 ./test/test.py`.
- Monitor D-Bus:

```bash
timeout 3 dbus-monitor --session "type='signal',interface='org.kde.StatusNotifierItem',member='NewToolTip'" 2>/dev/null | grep -c 'NewToolTip'

- Before: ~15 signals in 3 seconds.
- After: 0–1 signals when idle; updates only when download progress changes.

